### PR TITLE
FlatList onStartReached support

### DIFF
--- a/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
+++ b/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
@@ -103,11 +103,17 @@ export default (BaseFlatListExample: React.AbstractComponent<
   FlatList<string>,
 >);
 
+const ITEM_INNER_HEIGHT = 70;
+const ITEM_MARGIN = 8;
+export const ITEM_HEIGHT: number = ITEM_INNER_HEIGHT + ITEM_MARGIN * 2;
+
 const styles = StyleSheet.create({
   item: {
     backgroundColor: 'pink',
-    padding: 20,
-    marginVertical: 8,
+    paddingHorizontal: 20,
+    height: ITEM_INNER_HEIGHT,
+    marginVertical: ITEM_MARGIN,
+    justifyContent: 'center',
   },
   header: {
     fontSize: 32,

--- a/packages/rn-tester/js/examples/FlatList/FlatList-onStartReached.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-onStartReached.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+import BaseFlatListExample, {ITEM_HEIGHT} from './BaseFlatListExample';
+import * as React from 'react';
+
+export function FlatList_onStartReached(): React.Node {
+  const [output, setOutput] = React.useState('');
+  const exampleProps = {
+    onStartReached: info => setOutput('onStartReached'),
+    onStartReachedThreshold: 0,
+    initialScrollIndex: 5,
+    getItemLayout: (data, index) => ({
+      length: ITEM_HEIGHT,
+      offset: ITEM_HEIGHT * index,
+      index,
+    }),
+  };
+  const ref = React.useRef(null);
+
+  const onTest = () => {
+    const scrollResponder = ref?.current?.getScrollResponder();
+    if (scrollResponder != null) {
+      scrollResponder.scrollTo({y: 0});
+    }
+  };
+
+  return (
+    <BaseFlatListExample
+      ref={ref}
+      exampleProps={exampleProps}
+      testOutput={output}
+      onTest={onTest}
+    />
+  );
+}
+
+export default ({
+  title: 'onStartReached',
+  name: 'onStartReached',
+  description:
+    'Scroll to start of list or tap Test button to see `onStartReached` triggered.',
+  render: function (): React.Element<typeof FlatList_onStartReached> {
+    return <FlatList_onStartReached />;
+  },
+}: RNTesterModuleExample);

--- a/packages/rn-tester/js/examples/FlatList/FlatListExampleIndex.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatListExampleIndex.js
@@ -10,6 +10,7 @@
 
 import type {RNTesterModule} from '../../types/RNTesterTypes';
 import BasicExample from './FlatList-basic';
+import OnStartReachedExample from './FlatList-onStartReached';
 import OnEndReachedExample from './FlatList-onEndReached';
 import ContentInsetExample from './FlatList-contentInset';
 import InvertedExample from './FlatList-inverted';
@@ -27,6 +28,7 @@ export default ({
   showIndividualExamples: true,
   examples: [
     BasicExample,
+    OnStartReachedExample,
     OnEndReachedExample,
     ContentInsetExample,
     InvertedExample,


### PR DESCRIPTION
I ported some minor fixes from https://github.com/Expensify/react-native/pull/8 and added a simpler example that just tests onStartReached instead of the one that tests maintainVisibleContentPosition too.