### PR TITLE
[iOS] Fix item removal for maintainVisibleContentPosition

### DIFF
--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -934,14 +934,16 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
       return; // The prop might have changed in the previous UIBlocks, so need to abort here.
     }
     NSNumber *autoscrollThreshold = self->_maintainVisibleContentPosition[@"autoscrollToTopThreshold"];
+    CGRect newFrame = self->_firstVisibleView.frame;
     // TODO: detect and handle/ignore re-ordering
     if ([self isHorizontal:self->_scrollView]) {
-      CGFloat deltaX = self->_firstVisibleView.frame.origin.x - self->_prevFirstVisibleFrame.origin.x;
+      CGFloat deltaX = newFrame.origin.x - self->_prevFirstVisibleFrame.origin.x;
       if (ABS(deltaX) > 0.1) {
         CGFloat leftInset = self.inverted ? self->_scrollView.contentInset.right : self->_scrollView.contentInset.left;
         CGFloat x = self->_scrollView.contentOffset.x + leftInset;
-        self->_scrollView.contentOffset =
-            CGPointMake(self->_scrollView.contentOffset.x + deltaX, self->_scrollView.contentOffset.y);
+        self->_scrollView.contentOffset = deltaX <= 0.1 && self->_scrollView.contentOffset.x < newFrame.size.width
+          ? CGPointMake(0, self->_scrollView.contentOffset.y)
+          : CGPointMake(self->_scrollView.contentOffset.x + deltaX, 0);
         if (autoscrollThreshold != nil) {
           // If the offset WAS within the threshold of the start, animate to the start.
           if (x <= [autoscrollThreshold integerValue]) {
@@ -950,14 +952,14 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
         }
       }
     } else {
-      CGRect newFrame = self->_firstVisibleView.frame;
       CGFloat deltaY = newFrame.origin.y - self->_prevFirstVisibleFrame.origin.y;
       if (ABS(deltaY) > 0.1) {
         CGFloat bottomInset =
             self.inverted ? self->_scrollView.contentInset.top : self->_scrollView.contentInset.bottom;
         CGFloat y = self->_scrollView.contentOffset.y + bottomInset;
-        self->_scrollView.contentOffset =
-            CGPointMake(self->_scrollView.contentOffset.x, self->_scrollView.contentOffset.y + deltaY);
+        self->_scrollView.contentOffset = deltaY <= 0.1 && self->_scrollView.contentOffset.y < newFrame.size.height
+          ? CGPointMake(self->_scrollView.contentOffset.x, 0)
+          : CGPointMake(self->_scrollView.contentOffset.x, self->_scrollView.contentOffset.y + deltaY);
         if (autoscrollThreshold != nil) {
           // If the offset WAS within the threshold of the start, animate to the start.
           if (y <= [autoscrollThreshold integerValue]) {


### PR DESCRIPTION
This fixes item removal in the `maintainVisibleContentPosition` implementation.

## Summary
If you remove an item that's partially visible, and that item is at the index specified by `minIndexForVisible`, then the current `maintainVisibleContentPosition` prop implementation will leave you with empty space in the ScrollView.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

iOS Fixed - maintainVisibleContentPosition implementation for removal of items.

## Test Plan

1. Run the `rn-tester` app.
1. Add some items to the end of each list (vertical and horizontal) so that the list is scrollable.
1. Scroll down / to the right such that the first item in each list is halfway-visible.
1. Remove items from the top.
1. You should not be left with any empty space at the start of each `ScrollView`.

### Before
https://user-images.githubusercontent.com/47436092/182011677-613491de-8753-49ce-b08b-c599de3da90f.mov

### After
https://user-images.githubusercontent.com/47436092/182011687-6bfafcb8-581f-4ccd-923b-b114bf829fcf.mov