### PR TITLE
Add better example for maintainVisibleContentPosition bug with VirtualizedList

### DIFF
--- a/packages/rn-tester/js/components/ListExampleShared.js
+++ b/packages/rn-tester/js/components/ListExampleShared.js
@@ -13,6 +13,7 @@
 const React = require('react');
 
 const {
+  ActivityIndicator,
   Animated,
   Image,
   Platform,
@@ -33,16 +34,28 @@ export type Item = {
   ...
 };
 
-function genItemData(count: number, start: number = 0): Array<Item> {
+function genItemData(i): Item {
+  const itemHash = Math.abs(hashCode('Item ' + i));
+  return {
+    title: 'Item ' + i,
+    text: LOREM_IPSUM.substr(0, (itemHash % 301) + 20),
+    key: String(i),
+    pressed: false,
+  };
+}
+
+function genNewerItems(count: number, start: number = 0): Array<Item> {
   const dataBlob = [];
-  for (let ii = start; ii < count + start; ii++) {
-    const itemHash = Math.abs(hashCode('Item ' + ii));
-    dataBlob.push({
-      title: 'Item ' + ii,
-      text: LOREM_IPSUM.substr(0, (itemHash % 301) + 20),
-      key: String(ii),
-      pressed: false,
-    });
+  for (let i = start; i < count + start; i++) {
+    dataBlob.push(genItemData(i));
+  }
+  return dataBlob;
+}
+
+function genOlderItems(count: number, start: number = 0): Array<Item> {
+  const dataBlob = [];
+  for (let i = count; i > 0; i--) {
+    dataBlob.push(genItemData(start - i));
   }
   return dataBlob;
 }
@@ -146,6 +159,12 @@ class SeparatorComponent extends React.PureComponent<{...}> {
     return <View style={styles.separator} />;
   }
 }
+
+const LoadingComponent: React.ComponentType<{}> = React.memo(() => (
+  <View style={styles.loadingContainer}>
+    <ActivityIndicator />
+  </View>
+));
 
 class ItemSeparatorComponent extends React.PureComponent<$FlowFixMeProps> {
   render(): React.Node {
@@ -352,6 +371,13 @@ const styles = StyleSheet.create({
   text: {
     flex: 1,
   },
+  loadingContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 100,
+    borderTopWidth: 1,
+    borderTopColor: 'rgb(200, 199, 204)',
+  },
 });
 
 module.exports = {
@@ -362,8 +388,10 @@ module.exports = {
   ItemSeparatorComponent,
   PlainInput,
   SeparatorComponent,
+  LoadingComponent,
   Spindicator,
-  genItemData,
+  genNewerItems,
+  genOlderItems,
   getItemLayout,
   pressItem,
   renderSmallSwitchOption,

--- a/packages/rn-tester/js/components/ListExampleShared.js
+++ b/packages/rn-tester/js/components/ListExampleShared.js
@@ -34,7 +34,7 @@ export type Item = {
   ...
 };
 
-function genItemData(i): Item {
+function genItemData(i: number): Item {
   const itemHash = Math.abs(hashCode('Item ' + i));
   return {
     title: 'Item ' + i,

--- a/packages/rn-tester/js/examples/FlatList/FlatList-multiColumn.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-multiColumn.js
@@ -23,7 +23,7 @@ const {
   ItemComponent,
   PlainInput,
   SeparatorComponent,
-  genItemData,
+  genNewerItems,
   getItemLayout,
   pressItem,
   renderSmallSwitchOption,
@@ -46,7 +46,7 @@ class MultiColumnExample extends React.PureComponent<
         numColumns: number,
         virtualized: boolean,
       |} = {
-    data: genItemData(1000),
+    data: genNewerItems(1000),
     filterText: '',
     fixedHeight: true,
     logViewable: false,

--- a/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
@@ -21,7 +21,7 @@ const {
   PlainInput,
   SeparatorComponent,
   Spindicator,
-  genItemData,
+  genNewerItems,
   pressItem,
   renderSmallSwitchOption,
   renderStackedItem,
@@ -161,7 +161,7 @@ export function SectionList_scrollable(Props: {
   const [logViewable, setLogViewable] = React.useState(false);
   const [debug, setDebug] = React.useState(false);
   const [inverted, setInverted] = React.useState(false);
-  const [data, setData] = React.useState(genItemData(1000));
+  const [data, setData] = React.useState(genNewerItems(1000));
 
   const filterRegex = new RegExp(String(filterText), 'i');
   const filter = item =>


### PR DESCRIPTION
## Summary
Implements `onStartReached` and bidirectional pagination in the `FlatList-basic` example in rn-tester.
