### PR TITLE
Remove kotlin version

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -8,7 +8,7 @@
 plugins {
     id("com.android.library")
     id("com.facebook.react")
-    id("org.jetbrains.kotlin.android") version "1.6.10"
+    id("org.jetbrains.kotlin.android")
     id("maven-publish")
     id("de.undercouch.download")
 }


### PR DESCRIPTION
I had build issues with this, but not 100% sure it will be needed with npm published version. Can hold to test without it before merging.