### PR TITLE
Add support for numberOfLines and maximumNumberOfLines props on iOS and Android 

### DIFF
--- a/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -180,6 +180,13 @@ export type NativeProps = $ReadOnly<{|
   numberOfLines?: ?Int32,
 
   /**
+   * Sets the maximum number of lines for a `TextInput`. Use it with multiline set to
+   * `true` to be able to fill the lines.
+   * @platform android
+   */
+  maximumNumberOfLines?: ?Int32,
+
+  /**
    * When `false`, if there is a small amount of space available around a text input
    * (e.g. landscape orientation on a phone), the OS may choose to have the user edit
    * the text inside of a full screen text input mode. When `true`, this feature is

--- a/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -138,6 +138,8 @@ const RCTTextInputViewConfig = {
     placeholder: true,
     autoCorrect: true,
     multiline: true,
+    numberOfLines: true,
+    maximumNumberOfLines: true,
     textContentType: true,
     maxLength: true,
     autoCapitalize: true,

--- a/Libraries/Components/TextInput/TextInput.d.ts
+++ b/Libraries/Components/TextInput/TextInput.d.ts
@@ -423,12 +423,6 @@ export interface TextInputAndroidProps {
   inlineImagePadding?: number | undefined;
 
   /**
-   * Sets the number of lines for a TextInput.
-   * Use it with multiline set to true to be able to fill the lines.
-   */
-  numberOfLines?: number | undefined;
-
-  /**
    * Sets the return key to the label. Use it instead of `returnKeyType`.
    * @platform android
    */
@@ -618,9 +612,27 @@ export interface TextInputProps
   maxLength?: number | undefined;
 
   /**
+   * Sets the maximum number of lines for a TextInput.
+   * Use it with multiline set to true to be able to fill the lines.
+   */
+  maximumNumberOfLines?: number | undefined;
+
+  /**
    * If true, the text input can be multiple lines. The default value is false.
    */
   multiline?: boolean | undefined;
+
+  /**
+   * Sets the number of lines for a TextInput.
+   * Use it with multiline set to true to be able to fill the lines.
+   */
+  numberOfLines?: number | undefined;
+
+  /**
+   * Sets the number of rows for a TextInput.
+   * Use it with multiline set to true to be able to fill the lines.
+   */
+  rows?: number | undefined;
 
   /**
    * Callback that is called when the text input is blurred

--- a/Libraries/Components/TextInput/TextInput.flow.js
+++ b/Libraries/Components/TextInput/TextInput.flow.js
@@ -489,24 +489,10 @@ type AndroidProps = $ReadOnly<{|
   inlineImagePadding?: ?number,
 
   /**
-   * Sets the number of lines for a `TextInput`. Use it with multiline set to
-   * `true` to be able to fill the lines.
-   * @platform android
-   */
-  numberOfLines?: ?number,
-
-  /**
    * Sets the return key to the label. Use it instead of `returnKeyType`.
    * @platform android
    */
   returnKeyLabel?: ?string,
-
-  /**
-   * Sets the number of rows for a `TextInput`. Use it with multiline set to
-   * `true` to be able to fill the lines.
-   * @platform android
-   */
-  rows?: ?number,
 
   /**
    * When `false`, it will prevent the soft keyboard from showing when the field is focused.
@@ -657,6 +643,12 @@ export type Props = $ReadOnly<{|
   keyboardType?: ?KeyboardType,
 
   /**
+   * Sets the maximum number of lines for a `TextInput`. Use it with multiline set to
+   * `true` to be able to fill the lines.
+   */
+  maximumNumberOfLines?: ?number,
+
+  /**
    * Specifies largest possible scale a font can reach when `allowFontScaling` is enabled.
    * Possible values:
    * `null/undefined` (default): inherit from the parent node or the global default (0)
@@ -676,6 +668,12 @@ export type Props = $ReadOnly<{|
    * The default value is `false`.
    */
   multiline?: ?boolean,
+
+  /**
+   * Sets the number of lines for a `TextInput`. Use it with multiline set to
+   * `true` to be able to fill the lines.
+   */
+  numberOfLines?: ?number,
 
   /**
    * Callback that is called when the text input is blurred.
@@ -837,6 +835,12 @@ export type Props = $ReadOnly<{|
    * - `yahoo`
    */
   returnKeyType?: ?ReturnKeyType,
+
+  /**
+   * Sets the number of rows for a `TextInput`. Use it with multiline set to
+   * `true` to be able to fill the lines.
+   */
+  rows?: ?number,
 
   /**
    * If `true`, the text input obscures the text entered so that sensitive text

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -524,7 +524,6 @@ type AndroidProps = $ReadOnly<{|
   /**
    * Sets the number of lines for a `TextInput`. Use it with multiline set to
    * `true` to be able to fill the lines.
-   * @platform android
    */
   numberOfLines?: ?number,
 
@@ -537,9 +536,13 @@ type AndroidProps = $ReadOnly<{|
   /**
    * Sets the number of rows for a `TextInput`. Use it with multiline set to
    * `true` to be able to fill the lines.
-   * @platform android
    */
   rows?: ?number,
+
+  /**
+   * Sets the maximum number of lines the TextInput can have.
+   */
+  maximumNumberOfLines?: ?number,
 
   /**
    * When `false`, it will prevent the soft keyboard from showing when the field is focused.
@@ -1082,6 +1085,12 @@ const emptyFunctionThatReturnsTrue = () => true;
  *
  */
 function InternalTextInput(props: Props): React.Node {
+  const {
+    rows,
+    numberOfLines,
+    ...otherProps
+  } = props;
+
   const inputRef = useRef<null | React.ElementRef<HostComponent<mixed>>>(null);
 
   // Android sends a "onTextChanged" event followed by a "onSelectionChanged" event, for
@@ -1428,7 +1437,7 @@ function InternalTextInput(props: Props): React.Node {
     textInput = (
       <RCTTextInputView
         ref={_setNativeRef}
-        {...props}
+        {...otherProps}
         {...eventHandlers}
         accessible={accessible}
         accessibilityState={_accessibilityState}
@@ -1437,6 +1446,7 @@ function InternalTextInput(props: Props): React.Node {
         dataDetectorTypes={props.dataDetectorTypes}
         focusable={focusable}
         mostRecentEventCount={mostRecentEventCount}
+        numberOfLines={props.rows ?? props.numberOfLines}
         onBlur={_onBlur}
         onKeyPressSync={props.unstable_onKeyPressSync}
         onChange={_onChange}
@@ -1478,7 +1488,7 @@ function InternalTextInput(props: Props): React.Node {
        * fixed */
       <AndroidTextInput
         ref={_setNativeRef}
-        {...props}
+        {...otherProps}
         {...eventHandlers}
         accessible={accessible}
         accessibilityState={_accessibilityState}

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -59,6 +59,7 @@ const Text: React.AbstractComponent<
     pressRetentionOffset,
     role,
     suppressHighlighting,
+    numberOfLines,
     ...restProps
   } = props;
 
@@ -196,12 +197,12 @@ const Text: React.AbstractComponent<
     }
   }
 
-  let numberOfLines = restProps.numberOfLines;
+  let numberOfLinesValue = numberOfLines;
   if (numberOfLines != null && !(numberOfLines >= 0)) {
     console.error(
       `'numberOfLines' in <Text> must be a non-negative number, received: ${numberOfLines}. The value will be set to 0.`,
     );
-    numberOfLines = 0;
+    numberOfLinesValue = 0;
   }
 
   const hasTextAncestor = useContext(TextAncestor);
@@ -233,7 +234,7 @@ const Text: React.AbstractComponent<
       isPressable={isPressable}
       selectable={_selectable}
       nativeID={id ?? nativeID}
-      numberOfLines={numberOfLines}
+      maximumNumberOfLines={numberOfLinesValue}
       selectionColor={selectionColor}
       style={flattenedStyle}
       ref={forwardedRef}
@@ -259,7 +260,7 @@ const Text: React.AbstractComponent<
         ellipsizeMode={ellipsizeMode ?? 'tail'}
         isHighlighted={isHighlighted}
         nativeID={id ?? nativeID}
-        numberOfLines={numberOfLines}
+        maximumNumberOfLines={numberOfLinesValue}
         selectionColor={selectionColor}
         style={flattenedStyle}
         ref={forwardedRef}

--- a/Libraries/Text/Text/RCTTextViewManager.m
+++ b/Libraries/Text/Text/RCTTextViewManager.m
@@ -26,7 +26,7 @@
 
 RCT_EXPORT_MODULE(RCTText)
 
-RCT_REMAP_SHADOW_PROPERTY(numberOfLines, maximumNumberOfLines, NSInteger)
+RCT_EXPORT_SHADOW_PROPERTY(maximumNumberOfLines, NSInteger)
 RCT_REMAP_SHADOW_PROPERTY(ellipsizeMode, lineBreakMode, NSLineBreakMode)
 RCT_REMAP_SHADOW_PROPERTY(adjustsFontSizeToFit, adjustsFontSizeToFit, BOOL)
 RCT_REMAP_SHADOW_PROPERTY(minimumFontScale, minimumFontScale, CGFloat)

--- a/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputViewManager.m
+++ b/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputViewManager.m
@@ -7,6 +7,8 @@
 
 #import <React/RCTMultilineTextInputView.h>
 #import <React/RCTMultilineTextInputViewManager.h>
+#import <React/RCTUITextView.h>
+#import <React/RCTBaseTextInputShadowView.h>
 
 @implementation RCTMultilineTextInputViewManager
 
@@ -17,8 +19,21 @@ RCT_EXPORT_MODULE()
   return [[RCTMultilineTextInputView alloc] initWithBridge:self.bridge];
 }
 
+- (RCTShadowView *)shadowView
+{
+  RCTBaseTextInputShadowView *shadowView = (RCTBaseTextInputShadowView *)[super shadowView];
+
+  shadowView.maximumNumberOfLines = 0;
+  shadowView.exactNumberOfLines = 0;
+
+  return shadowView;
+}
+
 #pragma mark - Multiline <TextInput> (aka TextView) specific properties
 
 RCT_REMAP_VIEW_PROPERTY(dataDetectorTypes, backedTextInputView.dataDetectorTypes, UIDataDetectorTypes)
+
+RCT_EXPORT_SHADOW_PROPERTY(maximumNumberOfLines, NSInteger)
+RCT_REMAP_SHADOW_PROPERTY(numberOfLines, exactNumberOfLines, NSInteger)
 
 @end

--- a/Libraries/Text/TextInput/RCTBaseTextInputShadowView.h
+++ b/Libraries/Text/TextInput/RCTBaseTextInputShadowView.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSString *text;
 @property (nonatomic, copy, nullable) NSString *placeholder;
 @property (nonatomic, assign) NSInteger maximumNumberOfLines;
+@property (nonatomic, assign) NSInteger exactNumberOfLines;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onContentSizeChange;
 
 - (void)uiManagerWillPerformMounting;

--- a/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
@@ -218,7 +218,22 @@
 
 - (CGSize)sizeThatFitsMinimumSize:(CGSize)minimumSize maximumSize:(CGSize)maximumSize
 {
-  NSAttributedString *attributedText = [self measurableAttributedText];
+  NSMutableAttributedString *attributedText = [[self measurableAttributedText] mutableCopy];
+
+  /*
+  * The block below is responsible for setting the exact height of the view in lines
+  * Unfortunatelly, iOS doesn't export any easy way to do it. So we set maximumNumberOfLines
+  * prop and then add random lines at the front. However, they are only used for layout
+  * so they are not visible on the screen.
+  */
+  if (self.exactNumberOfLines) {
+    NSMutableString *newLines = [NSMutableString stringWithCapacity:self.exactNumberOfLines];
+    for (NSUInteger i = 0UL; i < self.exactNumberOfLines; ++i) {
+      [newLines appendString:@"\n"];
+    }
+    [attributedText insertAttributedString:[[NSAttributedString alloc] initWithString:newLines attributes:self.textAttributes.effectiveTextAttributes] atIndex:0];
+    _maximumNumberOfLines = self.exactNumberOfLines;
+  }
 
   if (!_textStorage) {
     _textContainer = [NSTextContainer new];

--- a/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputViewManager.m
+++ b/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputViewManager.m
@@ -19,6 +19,7 @@ RCT_EXPORT_MODULE()
   RCTBaseTextInputShadowView *shadowView = (RCTBaseTextInputShadowView *)[super shadowView];
 
   shadowView.maximumNumberOfLines = 1;
+  shadowView.exactNumberOfLines = 0;
 
   return shadowView;
 }

--- a/Libraries/Text/TextNativeComponent.js
+++ b/Libraries/Text/TextNativeComponent.js
@@ -18,6 +18,7 @@ import {type TextProps} from './TextProps';
 
 type NativeTextProps = $ReadOnly<{
   ...TextProps,
+  maximumNumberOfLines?: ?number,
   isHighlighted?: ?boolean,
   selectionColor?: ?ProcessedColorValue,
   onClick?: ?(event: PressEvent) => mixed,
@@ -31,7 +32,7 @@ const textViewConfig = {
   validAttributes: {
     isHighlighted: true,
     isPressable: true,
-    numberOfLines: true,
+    maximumNumberOfLines: true,
     ellipsizeMode: true,
     allowFontScaling: true,
     dynamicTypeRamp: true,

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewDefaults.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewDefaults.java
@@ -12,5 +12,6 @@ public class ViewDefaults {
 
   public static final float FONT_SIZE_SP = 14.0f;
   public static final int LINE_HEIGHT = 0;
-  public static final int NUMBER_OF_LINES = Integer.MAX_VALUE;
+  public static final int NUMBER_OF_LINES = -1;
+  public static final int MAXIMUM_NUMBER_OF_LINES = Integer.MAX_VALUE;
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -96,6 +96,7 @@ public class ViewProps {
   public static final String LETTER_SPACING = "letterSpacing";
   public static final String NEEDS_OFFSCREEN_ALPHA_COMPOSITING = "needsOffscreenAlphaCompositing";
   public static final String NUMBER_OF_LINES = "numberOfLines";
+  public static final String MAXIMUM_NUMBER_OF_LINES = "maximumNumberOfLines";
   public static final String ELLIPSIZE_MODE = "ellipsizeMode";
   public static final String ADJUSTS_FONT_SIZE_TO_FIT = "adjustsFontSizeToFit";
   public static final String MINIMUM_FONT_SCALE = "minimumFontScale";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -327,6 +327,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
   protected boolean mIsAccessibilityLink = false;
 
   protected int mNumberOfLines = UNSET;
+  protected int mMaxNumberOfLines = UNSET;
   protected int mTextAlign = Gravity.NO_GRAVITY;
   protected int mTextBreakStrategy =
       (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ? 0 : Layout.BREAK_STRATEGY_HIGH_QUALITY;
@@ -408,6 +409,12 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
   @ReactProp(name = ViewProps.NUMBER_OF_LINES, defaultInt = UNSET)
   public void setNumberOfLines(int numberOfLines) {
     mNumberOfLines = numberOfLines == 0 ? UNSET : numberOfLines;
+    markUpdated();
+  }
+
+  @ReactProp(name = ViewProps.MAXIMUM_NUMBER_OF_LINES, defaultInt = UNSET)
+  public void setMaxNumberOfLines(int numberOfLines) {
+    mMaxNumberOfLines = numberOfLines == 0 ? UNSET : numberOfLines;
     markUpdated();
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -54,6 +54,12 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
     view.setNumberOfLines(numberOfLines);
   }
 
+  // maxLines can only be set in master view (block), doesn't really make sense to set in a span
+  @ReactProp(name = ViewProps.MAXIMUM_NUMBER_OF_LINES, defaultInt = ViewDefaults.NUMBER_OF_LINES)
+  public void setMaxNumberOfLines(ReactTextView view, int numberOfLines) {
+    view.setNumberOfLines(numberOfLines);
+  }
+
   @ReactProp(name = ViewProps.ELLIPSIZE_MODE)
   public void setEllipsizeMode(ReactTextView view, @Nullable String ellipsizeMode) {
     if (ellipsizeMode == null || ellipsizeMode.equals("tail")) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -82,7 +82,7 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
             int minimumFontSize =
                 (int) Math.max(mMinimumFontScale * initialFontSize, PixelUtil.toPixelFromDIP(4));
             while (currentFontSize > minimumFontSize
-                && (mNumberOfLines != UNSET && layout.getLineCount() > mNumberOfLines
+                && (mMaxNumberOfLines != UNSET && layout.getLineCount() > mMaxNumberOfLines
                     || heightMode != YogaMeasureMode.UNDEFINED && layout.getHeight() > height)) {
               // TODO: We could probably use a smarter algorithm here. This will require 0(n)
               // measurements
@@ -124,9 +124,9 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
           }
 
           final int lineCount =
-              mNumberOfLines == UNSET
+            mMaxNumberOfLines == UNSET
                   ? layout.getLineCount()
-                  : Math.min(mNumberOfLines, layout.getLineCount());
+                  : Math.min(mMaxNumberOfLines, layout.getLineCount());
 
           // Instead of using `layout.getWidth()` (which may yield a significantly larger width for
           // text that is wrapping), compute width using the longest line.

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -18,6 +18,7 @@ import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.StaticLayout;
 import android.text.TextPaint;
+import android.text.TextUtils;
 import android.util.LayoutDirection;
 import android.util.LruCache;
 import android.view.View;
@@ -65,6 +66,7 @@ public class TextLayoutManager {
   private static final String TEXT_BREAK_STRATEGY_KEY = "textBreakStrategy";
   private static final String HYPHENATION_FREQUENCY_KEY = "android_hyphenationFrequency";
   private static final String MAXIMUM_NUMBER_OF_LINES_KEY = "maximumNumberOfLines";
+  private static final String NUMBER_OF_LINES_KEY = "numberOfLines";
   private static final LruCache<ReadableNativeMap, Spannable> sSpannableCache =
       new LruCache<>(spannableCacheSize);
   private static final ConcurrentHashMap<Integer, Spannable> sTagToSpannableCache =
@@ -384,6 +386,47 @@ public class TextLayoutManager {
         paragraphAttributes.hasKey(MAXIMUM_NUMBER_OF_LINES_KEY)
             ? paragraphAttributes.getInt(MAXIMUM_NUMBER_OF_LINES_KEY)
             : UNSET;
+
+    int numberOfLines =
+      paragraphAttributes.hasKey(NUMBER_OF_LINES_KEY)
+        ? paragraphAttributes.getInt(NUMBER_OF_LINES_KEY)
+        : UNSET;
+
+    int lines = layout.getLineCount();
+    if (numberOfLines != UNSET && numberOfLines != 0 && numberOfLines >= lines && text.length() > 0) {
+      int numberOfEmptyLines = numberOfLines - lines;
+      SpannableStringBuilder ssb = new SpannableStringBuilder();
+
+      // for some reason a newline on end causes issues with computing height so we add a character
+      if (text.toString().endsWith("\n")) {
+        ssb.append("A");
+      }
+
+      for (int i = 0; i < numberOfEmptyLines; ++i) {
+        ssb.append("\nA");
+      }
+
+      Object[] spans = text.getSpans(0, 0, Object.class);
+      for (Object span : spans) { // It's possible we need to set exl-exl
+        ssb.setSpan(span, 0, ssb.length(), text.getSpanFlags(span));
+      };
+
+      text = new SpannableStringBuilder(TextUtils.concat(text, ssb));
+      boring = null;
+      layout = createLayout(
+        text,
+        boring,
+        width,
+        widthYogaMeasureMode,
+        includeFontPadding,
+        textBreakStrategy,
+        hyphenationFrequency);
+    }
+
+
+    if (numberOfLines != UNSET && numberOfLines != 0) {
+      maximumNumberOfLines = numberOfLines;
+    }
 
     int calculatedLineCount =
         maximumNumberOfLines == UNSET || maximumNumberOfLines == 0

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -18,6 +18,7 @@ import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.StaticLayout;
 import android.text.TextPaint;
+import android.text.TextUtils;
 import android.util.LayoutDirection;
 import android.util.LruCache;
 import android.view.View;
@@ -61,6 +62,7 @@ public class TextLayoutManagerMapBuffer {
   public static final short PA_KEY_ADJUST_FONT_SIZE_TO_FIT = 3;
   public static final short PA_KEY_INCLUDE_FONT_PADDING = 4;
   public static final short PA_KEY_HYPHENATION_FREQUENCY = 5;
+  public static final short PA_KEY_NUMBER_OF_LINES = 6;
 
   private static final boolean ENABLE_MEASURE_LOGGING = ReactBuildConfig.DEBUG && false;
 
@@ -404,6 +406,46 @@ public class TextLayoutManagerMapBuffer {
         paragraphAttributes.contains(PA_KEY_MAX_NUMBER_OF_LINES)
             ? paragraphAttributes.getInt(PA_KEY_MAX_NUMBER_OF_LINES)
             : UNSET;
+
+    int numberOfLines =
+      paragraphAttributes.contains(PA_KEY_NUMBER_OF_LINES)
+        ? paragraphAttributes.getInt(PA_KEY_NUMBER_OF_LINES)
+        : UNSET;
+
+    int lines = layout.getLineCount();
+    if (numberOfLines != UNSET && numberOfLines != 0 && numberOfLines > lines && text.length() > 0) {
+      int numberOfEmptyLines = numberOfLines - lines;
+      SpannableStringBuilder ssb = new SpannableStringBuilder();
+
+      // for some reason a newline on end causes issues with computing height so we add a character
+      if (text.toString().endsWith("\n")) {
+        ssb.append("A");
+      }
+
+      for (int i = 0; i < numberOfEmptyLines; ++i) {
+        ssb.append("\nA");
+      }
+
+      Object[] spans = text.getSpans(0, 0, Object.class);
+      for (Object span : spans) { // It's possible we need to set exl-exl
+        ssb.setSpan(span, 0, ssb.length(), text.getSpanFlags(span));
+      };
+
+      text = new SpannableStringBuilder(TextUtils.concat(text, ssb));
+      boring = null;
+      layout = createLayout(
+        text,
+          boring,
+          width,
+          widthYogaMeasureMode,
+          includeFontPadding,
+          textBreakStrategy,
+          hyphenationFrequency);
+    }
+
+    if (numberOfLines != UNSET && numberOfLines != 0) {
+      maximumNumberOfLines = numberOfLines;
+    }
 
     int calculatedLineCount =
         maximumNumberOfLines == UNSET || maximumNumberOfLines == 0

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -477,7 +477,13 @@ public class ReactEditText extends AppCompatEditText
      * href='https://android.googlesource.com/platform/frameworks/base/+/jb-release/core/java/android/widget/TextView.java'>TextView.java</a>}
      */
     if (isMultiline()) {
+      // we save max lines as setSingleLines overwrites it
+      // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget/TextView.java#10671
+      int maxLines = getMaxLines();
       setSingleLine(false);
+      if (maxLines != -1) {
+        setMaxLines(maxLines);
+      }
     }
 
     // We override the KeyListener so that all keys on the soft input keyboard as well as hardware

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputLocalData.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputLocalData.java
@@ -41,9 +41,9 @@ public final class ReactTextInputLocalData {
   public void apply(EditText editText) {
     editText.setText(mText);
     editText.setTextSize(TypedValue.COMPLEX_UNIT_PX, mTextSize);
+    editText.setInputType(mInputType);
     editText.setMinLines(mMinLines);
     editText.setMaxLines(mMaxLines);
-    editText.setInputType(mInputType);
     editText.setHint(mPlaceholder);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       editText.setBreakStrategy(mBreakStrategy);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -723,7 +723,14 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
   @ReactProp(name = ViewProps.NUMBER_OF_LINES, defaultInt = 1)
   public void setNumLines(ReactEditText view, int numLines) {
+    view.setInputType(view.getInputType() | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
     view.setLines(numLines);
+  }
+
+  @ReactProp(name = ViewProps.MAXIMUM_NUMBER_OF_LINES, defaultInt = 1)
+  public void setMaxNumLines(ReactEditText view, int numLines) {
+    view.setInputType(view.getInputType() | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
+    view.setMaxLines(numLines);
   }
 
   @ReactProp(name = "maxLength")

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -117,6 +117,10 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
 
       if (mNumberOfLines != UNSET) {
         editText.setLines(mNumberOfLines);
+      } else {
+        if (mMaxNumberOfLines != UNSET) {
+          editText.setMaxLines(mMaxNumberOfLines);
+        }
       }
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M

--- a/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.cpp
+++ b/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.cpp
@@ -16,6 +16,7 @@ namespace facebook::react {
 
 bool ParagraphAttributes::operator==(const ParagraphAttributes &rhs) const {
   return std::tie(
+             numberOfLines,
              maximumNumberOfLines,
              ellipsizeMode,
              textBreakStrategy,
@@ -23,6 +24,7 @@ bool ParagraphAttributes::operator==(const ParagraphAttributes &rhs) const {
              includeFontPadding,
              android_hyphenationFrequency) ==
       std::tie(
+             rhs.numberOfLines,
              rhs.maximumNumberOfLines,
              rhs.ellipsizeMode,
              rhs.textBreakStrategy,
@@ -42,6 +44,7 @@ bool ParagraphAttributes::operator!=(const ParagraphAttributes &rhs) const {
 #if RN_DEBUG_STRING_CONVERTIBLE
 SharedDebugStringConvertibleList ParagraphAttributes::getDebugProps() const {
   return {
+      debugStringConvertibleItem("numberOfLines", numberOfLines),
       debugStringConvertibleItem("maximumNumberOfLines", maximumNumberOfLines),
       debugStringConvertibleItem("ellipsizeMode", ellipsizeMode),
       debugStringConvertibleItem("textBreakStrategy", textBreakStrategy),

--- a/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
+++ b/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
@@ -31,6 +31,11 @@ class ParagraphAttributes : public DebugStringConvertible {
 #pragma mark - Fields
 
   /*
+   *  Number of lines which paragraph takes.
+   */
+  int numberOfLines{};
+
+  /*
    * Maximum number of lines which paragraph can take.
    * Zero value represents "no limit".
    */
@@ -92,6 +97,7 @@ struct hash<facebook::react::ParagraphAttributes> {
       const facebook::react::ParagraphAttributes &attributes) const {
     return folly::hash::hash_combine(
         0,
+        attributes.numberOfLines,
         attributes.maximumNumberOfLines,
         attributes.ellipsizeMode,
         attributes.textBreakStrategy,

--- a/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -836,12 +836,18 @@ inline ParagraphAttributes convertRawProp(
     ParagraphAttributes const &defaultParagraphAttributes) {
   auto paragraphAttributes = ParagraphAttributes{};
 
-  paragraphAttributes.maximumNumberOfLines = convertRawProp(
+  paragraphAttributes.numberOfLines = convertRawProp(
       context,
       rawProps,
       "numberOfLines",
-      sourceParagraphAttributes.maximumNumberOfLines,
-      defaultParagraphAttributes.maximumNumberOfLines);
+      sourceParagraphAttributes.numberOfLines,
+      defaultParagraphAttributes.numberOfLines);
+  paragraphAttributes.maximumNumberOfLines = convertRawProp(
+       context,
+       rawProps,
+       "maximumNumberOfLines",
+       sourceParagraphAttributes.maximumNumberOfLines,
+       defaultParagraphAttributes.maximumNumberOfLines);
   paragraphAttributes.ellipsizeMode = convertRawProp(
       context,
       rawProps,
@@ -914,6 +920,7 @@ inline std::string toString(AttributedString::Range const &range) {
 inline folly::dynamic toDynamic(
     const ParagraphAttributes &paragraphAttributes) {
   auto values = folly::dynamic::object();
+  values("numberOfLines", paragraphAttributes.numberOfLines);
   values("maximumNumberOfLines", paragraphAttributes.maximumNumberOfLines);
   values("ellipsizeMode", toString(paragraphAttributes.ellipsizeMode));
   values("textBreakStrategy", toString(paragraphAttributes.textBreakStrategy));
@@ -1119,6 +1126,7 @@ constexpr static MapBuffer::Key PA_KEY_TEXT_BREAK_STRATEGY = 2;
 constexpr static MapBuffer::Key PA_KEY_ADJUST_FONT_SIZE_TO_FIT = 3;
 constexpr static MapBuffer::Key PA_KEY_INCLUDE_FONT_PADDING = 4;
 constexpr static MapBuffer::Key PA_KEY_HYPHENATION_FREQUENCY = 5;
+constexpr static MapBuffer::Key PA_KEY_NUMBER_OF_LINES = 6;
 
 inline MapBuffer toMapBuffer(const ParagraphAttributes &paragraphAttributes) {
   auto builder = MapBufferBuilder();
@@ -1136,6 +1144,8 @@ inline MapBuffer toMapBuffer(const ParagraphAttributes &paragraphAttributes) {
   builder.putString(
       PA_KEY_HYPHENATION_FREQUENCY,
       toString(paragraphAttributes.android_hyphenationFrequency));
+  builder.putInt(
+       PA_KEY_NUMBER_OF_LINES, paragraphAttributes.numberOfLines);
 
   return builder.build();
 }

--- a/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -56,6 +56,10 @@ AndroidTextInputProps::AndroidTextInputProps(
           "numberOfLines",
           sourceProps.numberOfLines,
           {0})),
+      maximumNumberOfLines(CoreFeatures::enablePropIteratorSetter? sourceProps.maximumNumberOfLines : convertRawProp(context, rawProps,
+            "maximumNumberOfLines",
+            sourceProps.maximumNumberOfLines,
+            {0})),
       disableFullscreenUI(CoreFeatures::enablePropIteratorSetter? sourceProps.disableFullscreenUI : convertRawProp(context, rawProps,
           "disableFullscreenUI",
           sourceProps.disableFullscreenUI,
@@ -281,6 +285,12 @@ void AndroidTextInputProps::setProp(
         value,
         paragraphAttributes,
         maximumNumberOfLines,
+        "maximumNumberOfLines");
+    REBUILD_FIELD_SWITCH_CASE(
+        paDefaults,
+        value,
+        paragraphAttributes,
+        numberOfLines,
         "numberOfLines");
     REBUILD_FIELD_SWITCH_CASE(
         paDefaults, value, paragraphAttributes, ellipsizeMode, "ellipsizeMode");
@@ -326,6 +336,7 @@ void AndroidTextInputProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(autoComplete, {});
     RAW_SET_PROP_SWITCH_CASE_BASIC(returnKeyLabel, {});
     RAW_SET_PROP_SWITCH_CASE_BASIC(numberOfLines, 0);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(maximumNumberOfLines, 0);
     RAW_SET_PROP_SWITCH_CASE_BASIC(disableFullscreenUI, false);
     RAW_SET_PROP_SWITCH_CASE_BASIC(textBreakStrategy, {});
     RAW_SET_PROP_SWITCH_CASE_BASIC(underlineColorAndroid, {});
@@ -419,6 +430,7 @@ void AndroidTextInputProps::setProp(
 // TODO T53300085: support this in codegen; this was hand-written
 folly::dynamic AndroidTextInputProps::getDynamic() const {
   folly::dynamic props = folly::dynamic::object();
+  props["maximumNumberOfLines"] = maximumNumberOfLines;
   props["autoComplete"] = autoComplete;
   props["returnKeyLabel"] = returnKeyLabel;
   props["numberOfLines"] = numberOfLines;

--- a/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/ReactCommon/react/renderer/components/textinput/androidtextinput/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -118,6 +118,7 @@ class AndroidTextInputProps final : public ViewProps, public BaseTextProps {
   std::string autoComplete{};
   std::string returnKeyLabel{};
   int numberOfLines{0};
+  int maximumNumberOfLines{0};
   bool disableFullscreenUI{false};
   std::string textBreakStrategy{};
   SharedColor underlineColorAndroid{};

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextLayoutManager.mm
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextLayoutManager.mm
@@ -170,26 +170,50 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   return paragraphLines;
 }
 
-- (NSTextStorage *)_textStorageAndLayoutManagerWithAttributesString:(NSAttributedString *)attributedString
+- (NSTextStorage *)_textStorageAndLayoutManagerWithAttributesString:(NSAttributedString *)inputAttributedString
                                                 paragraphAttributes:(ParagraphAttributes)paragraphAttributes
                                                                size:(CGSize)size
 {
-  NSTextContainer *textContainer = [[NSTextContainer alloc] initWithSize:size];
 
-  textContainer.lineFragmentPadding = 0.0; // Note, the default value is 5.
-  textContainer.lineBreakMode = paragraphAttributes.maximumNumberOfLines > 0
-      ? RCTNSLineBreakModeFromEllipsizeMode(paragraphAttributes.ellipsizeMode)
-      : NSLineBreakByClipping;
-  textContainer.maximumNumberOfLines = paragraphAttributes.maximumNumberOfLines;
+  NSMutableAttributedString *attributedString = [inputAttributedString mutableCopy];
 
+  /*
+    * The block below is responsible for setting the exact height of the view in lines
+    * Unfortunatelly, iOS doesn't export any easy way to do it. So we set maximumNumberOfLines
+    * prop and then add random lines at the front. However, they are only used for layout
+    * so they are not visible on the screen. This method is used for drawing only for Paragraph component
+    * but we set exact height in lines only on TextInput that doesn't use it. 
+    */
+  if (paragraphAttributes.numberOfLines) {
+    paragraphAttributes.maximumNumberOfLines = paragraphAttributes.numberOfLines;
+    NSMutableString *newLines = [NSMutableString stringWithCapacity: paragraphAttributes.numberOfLines];
+    for (NSUInteger i = 0UL; i < paragraphAttributes.numberOfLines; ++i) {
+      // K is added on purpose. New line seems to be not enough for NTtextContainer
+      [newLines appendString:@"K\n"];
+    }
+    NSDictionary<NSAttributedStringKey, id> * attributesOfFirstCharacter = [inputAttributedString attributesAtIndex:0 effectiveRange:NULL];
+      
+
+    [attributedString insertAttributedString:[[NSAttributedString alloc] initWithString:newLines attributes:attributesOfFirstCharacter] atIndex:0];
+  }
+    
+  NSTextContainer *textContainer = [NSTextContainer new];
+    
   NSLayoutManager *layoutManager = [NSLayoutManager new];
   layoutManager.usesFontLeading = NO;
   [layoutManager addTextContainer:textContainer];
-
-  NSTextStorage *textStorage = [[NSTextStorage alloc] initWithAttributedString:attributedString];
-
+  NSTextStorage *textStorage = [NSTextStorage new];
   [textStorage addLayoutManager:layoutManager];
 
+  textContainer.lineFragmentPadding = 0.0; // Note, the default value is 5.
+  textContainer.lineBreakMode = paragraphAttributes.maximumNumberOfLines > 0
+    ? RCTNSLineBreakModeFromEllipsizeMode(paragraphAttributes.ellipsizeMode)
+    : NSLineBreakByClipping;
+  textContainer.size = size;
+  textContainer.maximumNumberOfLines = paragraphAttributes.maximumNumberOfLines;
+
+  [textStorage replaceCharactersInRange:(NSRange){0, textStorage.length} withAttributedString:attributedString];
+    
   if (paragraphAttributes.adjustsFontSizeToFit) {
     CGFloat minimumFontSize = !isnan(paragraphAttributes.minimumFontSize) ? paragraphAttributes.minimumFontSize : 4.0;
     CGFloat maximumFontSize = !isnan(paragraphAttributes.maximumFontSize) ? paragraphAttributes.maximumFontSize : 96.0;

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
@@ -384,36 +384,6 @@ exports.examples = ([
     },
   },
   {
-    title: 'Fixed number of lines',
-    platform: 'android',
-    render: function (): React.Node {
-      return (
-        <View>
-          <TextInput
-            numberOfLines={2}
-            multiline={true}
-            placeholder="Two line input using numberOfLines prop"
-          />
-          <TextInput
-            numberOfLines={5}
-            multiline={true}
-            placeholder="Five line input using numberOfLines prop"
-          />
-          <TextInput
-            rows={2}
-            multiline={true}
-            placeholder="Two line input using rows prop"
-          />
-          <TextInput
-            rows={5}
-            multiline={true}
-            placeholder="Five line input using rows prop"
-          />
-        </View>
-      );
-    },
-  },
-  {
     title: 'Auto-expanding',
     render: function (): React.Node {
       return (

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -80,6 +80,12 @@ const styles = StyleSheet.create({
     fontSize: 13,
     padding: 4,
   },
+  textInputLines: {
+    borderWidth: 1,
+    borderColor: 'black',
+    padding: 0,
+    textAlignVertical: Platform.OS === 'android' ? 'top' : undefined,
+  },
 });
 
 class WithLabel extends React.Component<$FlowFixMeProps> {
@@ -869,6 +875,52 @@ module.exports = ([
     name: 'uncontrolledComponent',
     render: function (): React.Node {
       return <UncontrolledExample />;
+    },
+  },
+  {
+    title: 'Height in rows/lines',
+    name: 'rows',
+    render: function (): React.Node {
+      return (
+        <View>
+          <TextInput
+            numberOfLines={2}
+            multiline={true}
+            style={[styles.textInputLines, {marginBottom: 10}]}
+            placeholder="Two line input using numberOfLines prop"
+          />
+          <TextInput
+            numberOfLines={5}
+            multiline={true}
+            style={[styles.textInputLines, {marginBottom: 10}]}
+            placeholder="Five line input using numberOfLines prop"
+          />
+          <TextInput
+            rows={2}
+            multiline={true}
+            style={[styles.textInputLines, {marginBottom: 10}]}
+            placeholder="Two line input using rows prop"
+          />
+          <TextInput
+            rows={5}
+            multiline={true}
+            style={[styles.textInputLines, {marginBottom: 10}]}
+            placeholder="Five line input using rows prop"
+          />
+          <TextInput
+            maximumNumberOfLines={2}
+            multiline={true}
+            style={[styles.textInputLines, {marginBottom: 10}]}
+            placeholder="At most 2 lines"
+          />
+          <TextInput
+            maximumNumberOfLines={5}
+            multiline={true}
+            style={styles.textInputLines}
+            placeholder="At most 5 lines"
+          />
+        </View>
+      );
     },
   },
 ]: Array<RNTesterModuleExample>);


### PR DESCRIPTION
## Upstream PR
https://github.com/facebook/react-native/pull/35703

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

We want to be able to set height of TextArea/TextInput/EditText components on all platforms in the same way. Was is currently missing on iOS is expressing the height of a component in lines and this pr is supposed to fix it. Additionally in some cases we want to set maximum number of lines a "TextArea" like component can have. Because of Different screen sizes and accessibility settings it's sometimes hard to compute how many lines a current content takes so the purpose of `maximumNumberOfLines` prop is to simplify that process.

### iOS How it was implemented?
On Android the native "TextArea" like component (EditText) exposes `setLines` method that sets height of the component in lines. However, I wasn't able to find anything similar on iOS. What is a common method for both platforms is setting maximum height in lines. On iOS we can set `.maximumNumberOfLines` property on `TextContainer` and similarly on Android we can call `setMaxLines()` method to limit number of lines. So Adding `maximumNumberOfLines` is not a problem.   

I realised that when we add enough number of newLines in order to implement `numberOfLines` prop using `maximumNumberOfLines` functionality and did exactly that. Probably it's possible to get a font size and based on that set exact height but I didn't want to miss any edge cases and adding few newlines doesn't seem to be an overhead at all. 
Also probably otherwise we would need to take into account things like `space between lines`, `padding`...

### Android
I exposed `setMaxLines` in the same way `setLines` was exposed before so I'm pretty confident it's correct however I still need to test it.

### Fabric
I implemented numberOfLines and maximumNumberOfLines similarly to what I did for paper architecture but it turned out that there is one edge case. Whenever you tapped the enter button it added a new line to the text input. Even though NSTextContainer clearly had set maximumNumberOfLines property. I checked what are differences between paper and Fabric implementation when it comes to using NSTextContainer but I wasn't able to spot any difference. Fonts, spaces, other text attributes were exactly the same for every character. In RN docs I found that TextInput already have support for numberOfLines to I checked if the problem occurs also there. Turned out that problem is there too and moreover it's also in paper architecture. I checked differences on how NSContainer is used and spotted a different order of methods called on NSTextContainer, NSTextStorage and NSLayoutManager. After changing the order the problem is gone everywhere. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[CATEGORY] [TYPE] - Message

## Test Plan
I basically run the RNTester app with and without fabric.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
- [x] test iOS (Paper) 
- [x] test iOS (Fabric) 
- [ ] test Android (Paper)
- [ ] test Android (Fabric)
