### PR TITLE
Inline code block support

### DIFF
--- a/Libraries/Components/View/ReactNativeViewAttributes.js
+++ b/Libraries/Components/View/ReactNativeViewAttributes.js
@@ -35,7 +35,7 @@ const UIView = {
   collapsable: true,
   needsOffscreenAlphaCompositing: true,
   style: ReactNativeStyleAttributes,
-  textCodeBlock: true,
+  textCodeBlockStyle: true,
 };
 
 const RCTView = {

--- a/Libraries/Components/View/ReactNativeViewAttributes.js
+++ b/Libraries/Components/View/ReactNativeViewAttributes.js
@@ -35,6 +35,7 @@ const UIView = {
   collapsable: true,
   needsOffscreenAlphaCompositing: true,
   style: ReactNativeStyleAttributes,
+  textCodeBlock: true,
 };
 
 const RCTView = {

--- a/Libraries/Text/BaseText/RCTBaseTextViewManager.m
+++ b/Libraries/Text/BaseText/RCTBaseTextViewManager.m
@@ -55,5 +55,6 @@ RCT_REMAP_SHADOW_PROPERTY(textShadowColor, textAttributes.textShadowColor, UICol
 // Special
 RCT_REMAP_SHADOW_PROPERTY(isHighlighted, textAttributes.isHighlighted, BOOL)
 RCT_REMAP_SHADOW_PROPERTY(textTransform, textAttributes.textTransform, RCTTextTransform)
+RCT_REMAP_SHADOW_PROPERTY(textCodeBlock, textAttributes.textCodeBlock, NSDictionary)
 
 @end

--- a/Libraries/Text/BaseText/RCTBaseTextViewManager.m
+++ b/Libraries/Text/BaseText/RCTBaseTextViewManager.m
@@ -55,6 +55,6 @@ RCT_REMAP_SHADOW_PROPERTY(textShadowColor, textAttributes.textShadowColor, UICol
 // Special
 RCT_REMAP_SHADOW_PROPERTY(isHighlighted, textAttributes.isHighlighted, BOOL)
 RCT_REMAP_SHADOW_PROPERTY(textTransform, textAttributes.textTransform, RCTTextTransform)
-RCT_REMAP_SHADOW_PROPERTY(textCodeBlock, textAttributes.textCodeBlock, NSDictionary)
+RCT_REMAP_SHADOW_PROPERTY(textCodeBlockStyle, textAttributes.textCodeBlockStyle, NSDictionary)
 
 @end

--- a/Libraries/Text/RCTTextAttributes.h
+++ b/Libraries/Text/RCTTextAttributes.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const RCTTextAttributesIsHighlightedAttributeName;
 extern NSString *const RCTTextAttributesTagAttributeName;
-extern NSString *const RCTTextAttributesIsTextCodeBlockAttributeName;
+extern NSString *const RCTTextAttributesIsTextCodeBlockStyleAttributeName;
 
 /**
  * Represents knowledge about all supported *text* attributes
@@ -58,7 +58,7 @@ extern NSString *const RCTTextAttributesIsTextCodeBlockAttributeName;
 @property (nonatomic, strong, nullable) NSNumber *tag;
 @property (nonatomic, assign) UIUserInterfaceLayoutDirection layoutDirection;
 @property (nonatomic, assign) RCTTextTransform textTransform;
-@property (nonatomic, assign) NSDictionary *textCodeBlock;
+@property (nonatomic, assign) NSDictionary *textCodeBlockStyle;
 
 #pragma mark - Inheritance
 

--- a/Libraries/Text/RCTTextAttributes.h
+++ b/Libraries/Text/RCTTextAttributes.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const RCTTextAttributesIsHighlightedAttributeName;
 extern NSString *const RCTTextAttributesTagAttributeName;
+extern NSString *const RCTTextAttributesIsTextCodeBlockAttributeName;
 
 /**
  * Represents knowledge about all supported *text* attributes
@@ -57,6 +58,7 @@ extern NSString *const RCTTextAttributesTagAttributeName;
 @property (nonatomic, strong, nullable) NSNumber *tag;
 @property (nonatomic, assign) UIUserInterfaceLayoutDirection layoutDirection;
 @property (nonatomic, assign) RCTTextTransform textTransform;
+@property (nonatomic, assign) NSDictionary *textCodeBlock;
 
 #pragma mark - Inheritance
 

--- a/Libraries/Text/RCTTextAttributes.m
+++ b/Libraries/Text/RCTTextAttributes.m
@@ -13,7 +13,7 @@
 
 NSString *const RCTTextAttributesIsHighlightedAttributeName = @"RCTTextAttributesIsHighlightedAttributeName";
 NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttributeName";
-NSString *const RCTTextAttributesIsTextCodeBlockAttributeName = @"RCTTextAttributesIsTextCodeBlockAttributeName";
+NSString *const RCTTextAttributesIsTextCodeBlockStyleAttributeName = @"RCTTextAttributesIsTextCodeBlockStyleAttributeName";
 
 @implementation RCTTextAttributes
 
@@ -96,12 +96,12 @@ NSString *const RCTTextAttributesIsTextCodeBlockAttributeName = @"RCTTextAttribu
       : _layoutDirection;
   _textTransform =
       textAttributes->_textTransform != RCTTextTransformUndefined ? textAttributes->_textTransform : _textTransform;
-  _textCodeBlock = textAttributes->_textCodeBlock ?: _textCodeBlock;
+  _textCodeBlockStyle = textAttributes->_textCodeBlockStyle ?: _textCodeBlockStyle;
 }
 
-- (NSDictionary *)textCodeBlock
+- (NSDictionary *)textCodeBlockStyle
 {
-  return _textCodeBlock;
+  return _textCodeBlockStyle;
 }
 
 - (NSParagraphStyle *)effectiveParagraphStyle
@@ -218,8 +218,8 @@ NSString *const RCTTextAttributesIsTextCodeBlockAttributeName = @"RCTTextAttribu
     attributes[RCTTextAttributesTagAttributeName] = _tag;
   }
 
-  if (_textCodeBlock) {
-    attributes[RCTTextAttributesIsTextCodeBlockAttributeName] = _textCodeBlock;
+  if (_textCodeBlockStyle) {
+    attributes[RCTTextAttributesIsTextCodeBlockStyleAttributeName] = _textCodeBlockStyle;
   }
 
   return [attributes copy];
@@ -356,7 +356,7 @@ static NSString *capitalizeText(NSString *text)
       // Special
       RCTTextAttributesCompareOthers(_isHighlighted) && RCTTextAttributesCompareObjects(_tag) &&
       RCTTextAttributesCompareOthers(_layoutDirection) && RCTTextAttributesCompareOthers(_textTransform) &&
-      RCTTextAttributesCompareObjects(_textCodeBlock);
+      RCTTextAttributesCompareObjects(_textCodeBlockStyle);
 }
 
 @end

--- a/Libraries/Text/RCTTextAttributes.m
+++ b/Libraries/Text/RCTTextAttributes.m
@@ -13,6 +13,7 @@
 
 NSString *const RCTTextAttributesIsHighlightedAttributeName = @"RCTTextAttributesIsHighlightedAttributeName";
 NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttributeName";
+NSString *const RCTTextAttributesIsTextCodeBlockAttributeName = @"RCTTextAttributesIsTextCodeBlockAttributeName";
 
 @implementation RCTTextAttributes
 
@@ -95,6 +96,12 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
       : _layoutDirection;
   _textTransform =
       textAttributes->_textTransform != RCTTextTransformUndefined ? textAttributes->_textTransform : _textTransform;
+  _textCodeBlock = textAttributes->_textCodeBlock ?: _textCodeBlock;
+}
+
+- (NSDictionary *)textCodeBlock
+{
+  return _textCodeBlock;
 }
 
 - (NSParagraphStyle *)effectiveParagraphStyle
@@ -209,6 +216,10 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
 
   if (_tag) {
     attributes[RCTTextAttributesTagAttributeName] = _tag;
+  }
+
+  if (_textCodeBlock) {
+    attributes[RCTTextAttributesIsTextCodeBlockAttributeName] = _textCodeBlock;
   }
 
   return [attributes copy];
@@ -344,7 +355,8 @@ static NSString *capitalizeText(NSString *text)
       RCTTextAttributesCompareObjects(_textShadowColor) &&
       // Special
       RCTTextAttributesCompareOthers(_isHighlighted) && RCTTextAttributesCompareObjects(_tag) &&
-      RCTTextAttributesCompareOthers(_layoutDirection) && RCTTextAttributesCompareOthers(_textTransform);
+      RCTTextAttributesCompareOthers(_layoutDirection) && RCTTextAttributesCompareOthers(_textTransform) &&
+      RCTTextAttributesCompareObjects(_textCodeBlock);
 }
 
 @end

--- a/Libraries/Text/Text/RCTTextCodeBlock.h
+++ b/Libraries/Text/Text/RCTTextCodeBlock.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTTextCodeBlock : NSLayoutManager
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Libraries/Text/Text/RCTTextCodeBlock.m
+++ b/Libraries/Text/Text/RCTTextCodeBlock.m
@@ -62,8 +62,8 @@
                                      inTextContainer:textContainer
                                           usingBlock:^(CGRect enclosingRect, __unused BOOL *anotherStop) {
             
-            BOOL isFirstLine = lineGlyphRange.location == 0;
-            BOOL isLastLine = range.length + range.location == lineGlyphRange.length + lineGlyphRange.location;
+            BOOL isFirstLine = range.location >= lineGlyphRange.location;
+            BOOL isLastLine = range.length + range.location <= lineGlyphRange.length + lineGlyphRange.location;
             long corners = (
               (isFirstLine ? (UIRectCornerTopLeft | UIRectCornerBottomLeft) : 0) |
               (isLastLine ? (UIRectCornerTopRight | UIRectCornerBottomRight) : 0)

--- a/Libraries/Text/Text/RCTTextCodeBlock.m
+++ b/Libraries/Text/Text/RCTTextCodeBlock.m
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTTextCodeBlock.h"
+#import "RCTTextAttributes.h"
+
+@implementation RCTTextCodeBlock
+
+- (UIColor*)hexStringToColor:(NSString *)stringToConvert
+{
+    NSString *noHashString = [stringToConvert stringByReplacingOccurrencesOfString:@"#" withString:@""];
+    NSScanner *stringScanner = [NSScanner scannerWithString:noHashString];
+    
+    unsigned hex;
+    if (![stringScanner scanHexInt:&hex]) return nil;
+    int r = (hex >> 16) & 0xFF;
+    int g = (hex >> 8) & 0xFF;
+    int b = (hex) & 0xFF;
+    
+    return [UIColor colorWithRed:r / 255.0f green:g / 255.0f blue:b / 255.0f alpha:1.0f];
+}
+
+-(void)drawBackgroundForGlyphRange:(NSRange)glyphsToShow atPoint:(CGPoint)origin {
+    [super drawBackgroundForGlyphRange:glyphsToShow atPoint:origin];
+
+    if ((glyphsToShow.location + glyphsToShow.length) > [[self textStorage] length]) {
+      return;
+    }
+  
+    [[self textStorage] enumerateAttribute:RCTTextAttributesIsTextCodeBlockAttributeName
+                                    inRange:glyphsToShow
+                                    options:0
+                                 usingBlock:^(NSDictionary *textCodeBlock, NSRange range, __unused BOOL *stop) {
+
+      NSString *backgroundColor = [textCodeBlock objectForKey:@"backgroundColor"];
+      NSString *borderColor = [textCodeBlock objectForKey:@"borderColor"];
+      float borderRadius = [[textCodeBlock objectForKey:@"borderRadius"] floatValue];
+      float borderWidth = [[textCodeBlock objectForKey:@"borderWidth"] floatValue];
+      
+      CGContextRef context = UIGraphicsGetCurrentContext();
+      CGContextSetFillColorWithColor(context, [self hexStringToColor:backgroundColor].CGColor);
+      CGContextSetStrokeColorWithColor(context, [self hexStringToColor:borderColor].CGColor);
+      
+      if (!backgroundColor) {
+        return;
+      }
+      
+      // Enumerates line fragments intersecting with the whole text container.
+      [self enumerateLineFragmentsForGlyphRange:range
+                                     usingBlock:^(CGRect rect, CGRect usedRect, NSTextContainer * _Nonnull textContainer, NSRange lineGlyphRange, BOOL * _Nonnull stop) {
+        
+          __block UIBezierPath *textCodeBlockPath = nil;
+
+          NSRange lineRange = NSIntersectionRange(range, lineGlyphRange);
+        
+          [self enumerateEnclosingRectsForGlyphRange:lineRange
+                            withinSelectedGlyphRange:lineRange
+                                     inTextContainer:textContainer
+                                          usingBlock:^(CGRect enclosingRect, __unused BOOL *anotherStop) {
+            
+            BOOL isFirstLine = lineGlyphRange.location == 0;
+            BOOL isLastLine = range.length + range.location == lineGlyphRange.length + lineGlyphRange.location;
+            long corners = (
+              (isFirstLine ? (UIRectCornerTopLeft | UIRectCornerBottomLeft) : 0) |
+              (isLastLine ? (UIRectCornerTopRight | UIRectCornerBottomRight) : 0)
+            );
+
+            CGRect resultRect = CGRectMake(
+              enclosingRect.origin.x,
+              enclosingRect.origin.y + (borderWidth / 2),
+              enclosingRect.size.width + ((isFirstLine && isLastLine) || isLastLine ? 0 : 5),
+              enclosingRect.size.height - borderWidth
+            );
+
+            UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:resultRect byRoundingCorners:corners cornerRadii:CGSizeMake(borderRadius, borderRadius)];
+
+              if (textCodeBlockPath) {
+                [textCodeBlockPath appendPath:path];
+              } else {
+                textCodeBlockPath = path;
+              }
+              
+              textCodeBlockPath.lineWidth = borderWidth;
+              [textCodeBlockPath stroke];
+              [textCodeBlockPath fill];
+          }];
+      }];
+      
+    }];
+}
+
+@end

--- a/Libraries/Text/Text/RCTTextCodeBlockStyle.h
+++ b/Libraries/Text/Text/RCTTextCodeBlockStyle.h
@@ -9,7 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RCTTextCodeBlock : NSLayoutManager
+@interface RCTTextCodeBlockStyle : NSLayoutManager
 
 @end
 

--- a/Libraries/Text/Text/RCTTextCodeBlockStyle.m
+++ b/Libraries/Text/Text/RCTTextCodeBlockStyle.m
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import "RCTTextCodeBlock.h"
+#import "RCTTextCodeBlockStyle.h"
 #import "RCTTextAttributes.h"
 
-@implementation RCTTextCodeBlock
+@implementation RCTTextCodeBlockStyle
 
 - (UIColor*)hexStringToColor:(NSString *)stringToConvert
 {
@@ -31,15 +31,15 @@
       return;
     }
   
-    [[self textStorage] enumerateAttribute:RCTTextAttributesIsTextCodeBlockAttributeName
+    [[self textStorage] enumerateAttribute:RCTTextAttributesIsTextCodeBlockStyleAttributeName
                                     inRange:glyphsToShow
                                     options:0
-                                 usingBlock:^(NSDictionary *textCodeBlock, NSRange range, __unused BOOL *stop) {
+                                 usingBlock:^(NSDictionary *textCodeBlockStyle, NSRange range, __unused BOOL *stop) {
 
-      NSString *backgroundColor = [textCodeBlock objectForKey:@"backgroundColor"];
-      NSString *borderColor = [textCodeBlock objectForKey:@"borderColor"];
-      float borderRadius = [[textCodeBlock objectForKey:@"borderRadius"] floatValue];
-      float borderWidth = [[textCodeBlock objectForKey:@"borderWidth"] floatValue];
+      NSString *backgroundColor = [textCodeBlockStyle objectForKey:@"backgroundColor"];
+      NSString *borderColor = [textCodeBlockStyle objectForKey:@"borderColor"];
+      float borderRadius = [[textCodeBlockStyle objectForKey:@"borderRadius"] floatValue];
+      float borderWidth = [[textCodeBlockStyle objectForKey:@"borderWidth"] floatValue];
       
       CGContextRef context = UIGraphicsGetCurrentContext();
       CGContextSetFillColorWithColor(context, [self hexStringToColor:backgroundColor].CGColor);
@@ -53,7 +53,7 @@
       [self enumerateLineFragmentsForGlyphRange:range
                                      usingBlock:^(CGRect rect, CGRect usedRect, NSTextContainer * _Nonnull textContainer, NSRange lineGlyphRange, BOOL * _Nonnull stop) {
         
-          __block UIBezierPath *textCodeBlockPath = nil;
+          __block UIBezierPath *textCodeBlockStylePath = nil;
 
           NSRange lineRange = NSIntersectionRange(range, lineGlyphRange);
         
@@ -78,15 +78,15 @@
 
             UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:resultRect byRoundingCorners:corners cornerRadii:CGSizeMake(borderRadius, borderRadius)];
 
-              if (textCodeBlockPath) {
-                [textCodeBlockPath appendPath:path];
+              if (textCodeBlockStylePath) {
+                [textCodeBlockStylePath appendPath:path];
               } else {
-                textCodeBlockPath = path;
+                textCodeBlockStylePath = path;
               }
               
-              textCodeBlockPath.lineWidth = borderWidth;
-              [textCodeBlockPath stroke];
-              [textCodeBlockPath fill];
+              textCodeBlockStylePath.lineWidth = borderWidth;
+              [textCodeBlockStylePath stroke];
+              [textCodeBlockStylePath fill];
           }];
       }];
       

--- a/Libraries/Text/Text/RCTTextCodeBlockStyle.m
+++ b/Libraries/Text/Text/RCTTextCodeBlockStyle.m
@@ -40,6 +40,8 @@
       NSString *borderColor = [textCodeBlockStyle objectForKey:@"borderColor"];
       float borderRadius = [[textCodeBlockStyle objectForKey:@"borderRadius"] floatValue];
       float borderWidth = [[textCodeBlockStyle objectForKey:@"borderWidth"] floatValue];
+      float horizontalOffset = 5;
+      float verticalOffset = 2;
       
       CGContextRef context = UIGraphicsGetCurrentContext();
       CGContextSetFillColorWithColor(context, [self hexStringToColor:backgroundColor].CGColor);
@@ -72,8 +74,8 @@
             CGRect resultRect = CGRectMake(
               enclosingRect.origin.x,
               enclosingRect.origin.y + (borderWidth / 2),
-              enclosingRect.size.width + ((isFirstLine && isLastLine) || isLastLine ? 0 : 5),
-              enclosingRect.size.height - borderWidth
+              enclosingRect.size.width + ((isFirstLine && isLastLine) || isLastLine ? 0 : horizontalOffset),
+              enclosingRect.size.height - borderWidth - verticalOffset
             );
 
             UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:resultRect byRoundingCorners:corners cornerRadii:CGSizeMake(borderRadius, borderRadius)];

--- a/Libraries/Text/Text/RCTTextCodeBlockStyle.m
+++ b/Libraries/Text/Text/RCTTextCodeBlockStyle.m
@@ -73,7 +73,7 @@
 
             CGRect resultRect = CGRectMake(
               enclosingRect.origin.x,
-              enclosingRect.origin.y + (borderWidth / 2),
+              enclosingRect.origin.y + (borderWidth / 2) + (verticalOffset / 2),
               enclosingRect.size.width + ((isFirstLine && isLastLine) || isLastLine ? 0 : horizontalOffset),
               enclosingRect.size.height - borderWidth - verticalOffset
             );

--- a/Libraries/Text/Text/RCTTextCodeBlockStyle.m
+++ b/Libraries/Text/Text/RCTTextCodeBlockStyle.m
@@ -73,9 +73,9 @@
 
             CGRect resultRect = CGRectMake(
               enclosingRect.origin.x,
-              enclosingRect.origin.y + (borderWidth / 2) + (verticalOffset / 2),
+              enclosingRect.origin.y + (borderWidth / 2) + verticalOffset,
               enclosingRect.size.width + ((isFirstLine && isLastLine) || isLastLine ? 0 : horizontalOffset),
-              enclosingRect.size.height - borderWidth - verticalOffset
+              enclosingRect.size.height - (borderWidth * 2)
             );
 
             UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:resultRect byRoundingCorners:corners cornerRadii:CGSizeMake(borderRadius, borderRadius)];

--- a/Libraries/Text/Text/RCTTextShadowView.m
+++ b/Libraries/Text/Text/RCTTextShadowView.m
@@ -14,6 +14,7 @@
 
 #import <React/RCTTextView.h>
 #import "NSTextStorage+FontScaling.h"
+#import "RCTTextCodeBlock.h"
 
 @implementation RCTTextShadowView {
   __weak RCTBridge *_bridge;
@@ -219,7 +220,7 @@
   textContainer.lineBreakMode = _maximumNumberOfLines > 0 ? _lineBreakMode : NSLineBreakByClipping;
   textContainer.maximumNumberOfLines = _maximumNumberOfLines;
 
-  NSLayoutManager *layoutManager = [NSLayoutManager new];
+  NSLayoutManager *layoutManager = [RCTTextCodeBlock new];
   layoutManager.usesFontLeading = NO;
   [layoutManager addTextContainer:textContainer];
 

--- a/Libraries/Text/Text/RCTTextShadowView.m
+++ b/Libraries/Text/Text/RCTTextShadowView.m
@@ -14,7 +14,7 @@
 
 #import <React/RCTTextView.h>
 #import "NSTextStorage+FontScaling.h"
-#import "RCTTextCodeBlock.h"
+#import "RCTTextCodeBlockStyle.h"
 
 @implementation RCTTextShadowView {
   __weak RCTBridge *_bridge;
@@ -220,7 +220,7 @@
   textContainer.lineBreakMode = _maximumNumberOfLines > 0 ? _lineBreakMode : NSLineBreakByClipping;
   textContainer.maximumNumberOfLines = _maximumNumberOfLines;
 
-  NSLayoutManager *layoutManager = [RCTTextCodeBlock new];
+  NSLayoutManager *layoutManager = [RCTTextCodeBlockStyle new];
   layoutManager.usesFontLeading = NO;
   [layoutManager addTextContainer:textContainer];
 

--- a/Libraries/Text/TextCodeBlock.js
+++ b/Libraries/Text/TextCodeBlock.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
+
+export type TextCodeBlockProp = $ReadOnly<{|
+  /**
+   * The background color of the text code block.
+   */
+  backgroundColor?: ?ColorValue,
+
+  /**
+   * The border color of the text code block.
+   */
+  borderColor?: ?ColorValue,
+
+  /**
+   * The border radius of the text code block.
+   */
+  borderRadius?: ?number,
+
+  /**
+   * The border width of the text code block.
+   */
+  borderWidth?: ?number,
+|}>;

--- a/Libraries/Text/TextCodeBlock.js
+++ b/Libraries/Text/TextCodeBlock.js
@@ -10,7 +10,7 @@
 
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-export type TextCodeBlockProp = $ReadOnly<{|
+export type TextCodeBlockStyleProp = $ReadOnly<{|
   /**
    * The background color of the text code block.
    */

--- a/Libraries/Text/TextNativeComponent.js
+++ b/Libraries/Text/TextNativeComponent.js
@@ -47,6 +47,7 @@ const textViewConfig = {
     dataDetectorType: true,
     android_hyphenationFrequency: true,
     lineBreakStrategyIOS: true,
+    textCodeBlock: true,
   },
   directEventTypes: {
     topTextLayout: {
@@ -64,6 +65,7 @@ const virtualTextViewConfig = {
     isHighlighted: true,
     isPressable: true,
     maxFontSizeMultiplier: true,
+    textCodeBlock: true,
   },
   uiViewClassName: 'RCTVirtualText',
 };

--- a/Libraries/Text/TextNativeComponent.js
+++ b/Libraries/Text/TextNativeComponent.js
@@ -47,7 +47,7 @@ const textViewConfig = {
     dataDetectorType: true,
     android_hyphenationFrequency: true,
     lineBreakStrategyIOS: true,
-    textCodeBlock: true,
+    textCodeBlockStyle: true,
   },
   directEventTypes: {
     topTextLayout: {
@@ -65,7 +65,7 @@ const virtualTextViewConfig = {
     isHighlighted: true,
     isPressable: true,
     maxFontSizeMultiplier: true,
-    textCodeBlock: true,
+    textCodeBlockStyle: true,
   },
   uiViewClassName: 'RCTVirtualText',
 };

--- a/Libraries/Text/TextProps.js
+++ b/Libraries/Text/TextProps.js
@@ -24,7 +24,7 @@ import type {
   PressEvent,
   TextLayoutEvent,
 } from '../Types/CoreEventTypes';
-import type {TextCodeBlockProp} from './TextCodeBlock';
+import type {TextCodeBlockStyleProp} from './TextCodeBlockStyle';
 import type {Node} from 'react';
 
 export type PressRetentionOffset = $ReadOnly<{|
@@ -273,5 +273,5 @@ export type TextProps = $ReadOnly<{|
    *
    * See https://github.com/Expensify/App/issues/4733
    */
-  textCodeBlock?: ?TextCodeBlockProp,
+  textCodeBlockStyle?: ?TextCodeBlockStyleProp,
 |}>;

--- a/Libraries/Text/TextProps.js
+++ b/Libraries/Text/TextProps.js
@@ -24,6 +24,7 @@ import type {
   PressEvent,
   TextLayoutEvent,
 } from '../Types/CoreEventTypes';
+import type {TextCodeBlockProp} from './TextCodeBlock';
 import type {Node} from 'react';
 
 export type PressRetentionOffset = $ReadOnly<{|
@@ -266,4 +267,11 @@ export type TextProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/text.html#linebreakstrategyios
    */
   lineBreakStrategyIOS?: ?('none' | 'standard' | 'hangul-word' | 'push-out'),
+
+  /*
+   * Draws inline border around text with background, mostly used for inline code blocks.
+   *
+   * See https://github.com/Expensify/App/issues/4733
+   */
+  textCodeBlock?: ?TextCodeBlockProp,
 |}>;

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -159,7 +159,7 @@ public class ViewProps {
   public static final String ACCESSIBILITY_VALUE = "accessibilityValue";
   public static final String ACCESSIBILITY_LABELLED_BY = "accessibilityLabelledBy";
   public static final String IMPORTANT_FOR_ACCESSIBILITY = "importantForAccessibility";
-  public static final String TEXT_CODE_BLOCK = "textCodeBlock";
+  public static final String TEXT_CODE_BLOCK = "textCodeBlockStyle";
 
   // DEPRECATED
   public static final String ROTATION = "rotation";

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -159,6 +159,7 @@ public class ViewProps {
   public static final String ACCESSIBILITY_VALUE = "accessibilityValue";
   public static final String ACCESSIBILITY_LABELLED_BY = "accessibilityLabelledBy";
   public static final String IMPORTANT_FOR_ACCESSIBILITY = "importantForAccessibility";
+  public static final String TEXT_CODE_BLOCK = "textCodeBlock";
 
   // DEPRECATED
   public static final String ROTATION = "rotation";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactInlineBorderSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactInlineBorderSpan.java
@@ -31,22 +31,22 @@ public class ReactInlineBorderSpan implements LineBackgroundSpan, ReactSpan {
   private int borderRadius;
   private int borderWidth;
 
-  public ReactInlineBorderSpan(int effectiveFontSize, int effectiveStart, int effectiveEnd, ReadableMap textCodeBlock) {
+  public ReactInlineBorderSpan(int effectiveFontSize, int effectiveStart, int effectiveEnd, ReadableMap textCodeBlockStyle) {
     this.effectiveFontSize = effectiveFontSize;
     this.effectiveStart = effectiveStart;
     this.effectiveEnd = effectiveEnd;
     
-    if (textCodeBlock.hasKey("backgroundColor") && !textCodeBlock.isNull("backgroundColor")) {
-      this.backgroundColor = Color.parseColor(textCodeBlock.getString("backgroundColor"));
+    if (textCodeBlockStyle.hasKey("backgroundColor") && !textCodeBlockStyle.isNull("backgroundColor")) {
+      this.backgroundColor = Color.parseColor(textCodeBlockStyle.getString("backgroundColor"));
     }
-    if (textCodeBlock.hasKey("borderColor") && !textCodeBlock.isNull("borderColor")) {
-      this.borderColor = Color.parseColor(textCodeBlock.getString("borderColor"));
+    if (textCodeBlockStyle.hasKey("borderColor") && !textCodeBlockStyle.isNull("borderColor")) {
+      this.borderColor = Color.parseColor(textCodeBlockStyle.getString("borderColor"));
     }
-    if (textCodeBlock.hasKey("borderRadius") && !textCodeBlock.isNull("borderRadius")) {
-      this.borderRadius = (int) PixelUtil.toPixelFromDIP((float) textCodeBlock.getInt("borderRadius"));
+    if (textCodeBlockStyle.hasKey("borderRadius") && !textCodeBlockStyle.isNull("borderRadius")) {
+      this.borderRadius = (int) PixelUtil.toPixelFromDIP((float) textCodeBlockStyle.getInt("borderRadius"));
     }
-    if (textCodeBlock.hasKey("borderWidth") && !textCodeBlock.isNull("borderWidth")) {
-      this.borderWidth = textCodeBlock.getInt("borderWidth");
+    if (textCodeBlockStyle.hasKey("borderWidth") && !textCodeBlockStyle.isNull("borderWidth")) {
+      this.borderWidth = textCodeBlockStyle.getInt("borderWidth");
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactInlineBorderSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactInlineBorderSpan.java
@@ -109,7 +109,7 @@ public class ReactInlineBorderSpan implements LineBackgroundSpan, ReactSpan {
       return new float[]{this.borderRadius, this.borderRadius, this.borderRadius, this.borderRadius, this.borderRadius, this.borderRadius, this.borderRadius, this.borderRadius};
     }
 
-    if (lineNumber == 0 && end <= effectiveEnd) {
+    if (start <= effectiveStart && end <= effectiveEnd) {
       return new float[]{this.borderRadius, this.borderRadius, 0, 0, 0, 0, this.borderRadius, this.borderRadius};
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactInlineBorderSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactInlineBorderSpan.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.text;
+
+import android.graphics.Paint;
+import android.text.style.LineBackgroundSpan;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.Color;
+import android.graphics.Path;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.PixelUtil;
+
+/**
+ * We use a custom {@link LineBackgroundSpan}, because RN Text component can't render borders. Details here:
+ * https://github.com/Expensify/App/issues/4733
+ */
+public class ReactInlineBorderSpan implements LineBackgroundSpan, ReactSpan {
+  private final int effectiveStart;
+  private final int effectiveEnd;
+  private final int effectiveFontSize;
+
+  private int backgroundColor;
+  private int borderColor;
+  private int borderRadius;
+  private int borderWidth;
+
+  public ReactInlineBorderSpan(int effectiveFontSize, int effectiveStart, int effectiveEnd, ReadableMap textCodeBlock) {
+    this.effectiveFontSize = effectiveFontSize;
+    this.effectiveStart = effectiveStart;
+    this.effectiveEnd = effectiveEnd;
+    
+    if (textCodeBlock.hasKey("backgroundColor") && !textCodeBlock.isNull("backgroundColor")) {
+      this.backgroundColor = Color.parseColor(textCodeBlock.getString("backgroundColor"));
+    }
+    if (textCodeBlock.hasKey("borderColor") && !textCodeBlock.isNull("borderColor")) {
+      this.borderColor = Color.parseColor(textCodeBlock.getString("borderColor"));
+    }
+    if (textCodeBlock.hasKey("borderRadius") && !textCodeBlock.isNull("borderRadius")) {
+      this.borderRadius = (int) PixelUtil.toPixelFromDIP((float) textCodeBlock.getInt("borderRadius"));
+    }
+    if (textCodeBlock.hasKey("borderWidth") && !textCodeBlock.isNull("borderWidth")) {
+      this.borderWidth = textCodeBlock.getInt("borderWidth");
+    }
+  }
+
+  /**
+   * Calculates text start and end position per given lines text range
+   */
+  private int[] calculateBorderedTextCharRange(int lineStart, int lineEnd) {
+    /**
+     * If bordered text's position falls within the lines size range return the position of bordered text's first char
+     * Otherwise return lines start position.
+     * 
+     * e.g. given paragraph below:
+     * This is a sample text [and the bordered | prependedTextStart -> 23, prependedTextEnd -> 39
+     * text starts and ends here].             | prependedTextStart -> 24, prependedTextEnd -> 65
+     */
+    int prependedTextStart = (lineStart < this.effectiveStart && lineEnd > this.effectiveStart) ? this.effectiveStart : lineStart;
+    int prependedTextEnd = (lineEnd < effectiveEnd) ? lineEnd : effectiveEnd;
+
+    return new int[]{prependedTextStart, prependedTextEnd};
+  }
+
+  /**
+   * Generate Rect that will be used to cover bordered background layer.
+   */
+  private RectF generateTextBounds(Canvas canvas, Paint paint, int left, int right, int top, int baseline, int bottom, CharSequence text, int start, int end, int lineNumber) {
+    int[] borderedTextRange = this.calculateBorderedTextCharRange(start, end);
+    
+    /**
+     * Set's RN Text size for the canvas to measure accurate metrics
+     * Calculate bordered text's background layer position relative to the line.
+     * 
+     * e.g. given the line below
+     * This is a prepended [this is bordered] text.
+     */
+    paint.setTextSize(this.effectiveFontSize + PixelUtil.toPixelFromDIP(2));
+    int prependedTextWidth = Math.round(paint.measureText(text, start, borderedTextRange[0]));
+    
+    paint.setTextSize(this.effectiveFontSize);
+    int borderedTextWidth = Math.round(paint.measureText(text, borderedTextRange[0], borderedTextRange[1]));
+
+    RectF rect = new RectF();
+
+    /**
+     * Overflow offset to hide border radius on leading lines,
+     * so that left border radius is only shown on first and right on last line.
+     */
+    int offset = (int) PixelUtil.toPixelFromDIP(5f);
+    int leftPosition = prependedTextWidth - (lineNumber == 0 ? 0 : offset);
+    int rightPosition = prependedTextWidth + borderedTextWidth + (end < effectiveEnd ? offset : 0);
+    rect.set(leftPosition, top + borderWidth / 2, rightPosition, bottom - borderWidth / 2);
+
+    return rect;
+  }
+
+  /**
+   * Generate border radius for each line.
+   */
+  private float[] generateTextCorners(Canvas canvas, Paint paint, int left, int right, int top, int baseline, int bottom, CharSequence text, int start, int end, int lineNumber) {
+    if (lineNumber == 0 && end >= effectiveEnd) {
+      return new float[]{this.borderRadius, this.borderRadius, this.borderRadius, this.borderRadius, this.borderRadius, this.borderRadius, this.borderRadius, this.borderRadius};
+    }
+
+    if (lineNumber == 0 && end <= effectiveEnd) {
+      return new float[]{this.borderRadius, this.borderRadius, 0, 0, 0, 0, this.borderRadius, this.borderRadius};
+    }
+
+    if (end >= effectiveEnd) {
+      return new float[]{0, 0, this.borderRadius, this.borderRadius, this.borderRadius, this.borderRadius, 0, 0};
+    }
+
+    return new float[]{0, 0, 0, 0, 0, 0, 0, 0};
+  }
+
+
+  @Override
+  public void drawBackground(Canvas canvas, Paint paint, int left, int right, int top, int baseline, int bottom, CharSequence text, int start, int end, int lineNumber) {
+    float[] corners = generateTextCorners(canvas, paint, left, right, top, baseline, bottom, text, start, end, lineNumber);
+    final Path path = new Path();
+
+    RectF rect = generateTextBounds(canvas, paint, left, right, top, baseline, bottom, text, start, end, lineNumber);
+    path.addRoundRect(rect, corners, Path.Direction.CW);
+
+    /**
+     * Draw filled background 
+     */
+    Paint backgroundPaint = new Paint();
+    backgroundPaint.setColor(this.backgroundColor);
+    backgroundPaint.setStyle(Paint.Style.FILL);
+    canvas.drawPath(path, backgroundPaint);
+
+    /**
+     * Draw border
+     */
+    Paint borderPaint = new Paint();
+    borderPaint.setColor(this.borderColor);
+    borderPaint.setStyle(Paint.Style.STROKE);
+    borderPaint.setStrokeWidth(this.borderWidth);
+    borderPaint.setStrokeCap(Paint.Cap.ROUND);
+    canvas.drawPath(path, borderPaint);
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactInlineBorderSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactInlineBorderSpan.java
@@ -95,8 +95,8 @@ public class ReactInlineBorderSpan implements LineBackgroundSpan, ReactSpan {
      */
     int horizontalOffset = (int) PixelUtil.toPixelFromDIP(5f);
     int verticalOffset = (int) PixelUtil.toPixelFromDIP(1f);
-    int topPosition = top + (borderWidth / 2) + verticalOffset;
-    int bottomPosition = bottom - (borderWidth / 2) - verticalOffset;
+    int topPosition = top + (borderWidth * 2) + (verticalOffset * 2);
+    int bottomPosition = bottom - (borderWidth / 2);
     int leftPosition = prependedTextWidth - (lineNumber == 0 ? 0 : horizontalOffset);
     int rightPosition = prependedTextWidth + borderedTextWidth + (end < effectiveEnd ? horizontalOffset : 0);
     rect.set(leftPosition, topPosition, rightPosition, bottomPosition);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactInlineBorderSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactInlineBorderSpan.java
@@ -93,10 +93,13 @@ public class ReactInlineBorderSpan implements LineBackgroundSpan, ReactSpan {
      * Overflow offset to hide border radius on leading lines,
      * so that left border radius is only shown on first and right on last line.
      */
-    int offset = (int) PixelUtil.toPixelFromDIP(5f);
-    int leftPosition = prependedTextWidth - (lineNumber == 0 ? 0 : offset);
-    int rightPosition = prependedTextWidth + borderedTextWidth + (end < effectiveEnd ? offset : 0);
-    rect.set(leftPosition, top + borderWidth / 2, rightPosition, bottom - borderWidth / 2);
+    int horizontalOffset = (int) PixelUtil.toPixelFromDIP(5f);
+    int verticalOffset = (int) PixelUtil.toPixelFromDIP(1f);
+    int topPosition = top + (borderWidth / 2) + verticalOffset;
+    int bottomPosition = bottom - (borderWidth / 2) - verticalOffset;
+    int leftPosition = prependedTextWidth - (lineNumber == 0 ? 0 : horizontalOffset);
+    int rightPosition = prependedTextWidth + borderedTextWidth + (end < effectiveEnd ? horizontalOffset : 0);
+    rect.set(leftPosition, topPosition, rightPosition, bottomPosition);
 
     return rect;
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -16,6 +16,8 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.mapbuffer.MapBuffer;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactAccessibilityDelegate;
@@ -53,6 +55,12 @@ public class TextAttributeProps {
   public static final short TA_KEY_IS_HIGHLIGHTED = 20;
   public static final short TA_KEY_LAYOUT_DIRECTION = 21;
   public static final short TA_KEY_ACCESSIBILITY_ROLE = 22;
+  public static final short TA_KEY_TEXT_CODE_BLOCK = 30;
+
+  public static final short TCB_KEY_BACKGROUND_COLOR = 0;
+  public static final short TCB_KEY_BORDER_COLOR = 1;
+  public static final short TCB_KEY_BORDER_RADIUS = 2;
+  public static final short TCB_KEY_BORDER_WIDTH = 3;
 
   public static final int UNSET = -1;
 
@@ -85,6 +93,7 @@ public class TextAttributeProps {
   protected float mLineHeightInput = UNSET;
   protected float mLetterSpacingInput = Float.NaN;
   protected int mTextAlign = Gravity.NO_GRAVITY;
+  protected ReadableMap mTextCodeBlock;
 
   // `UNSET` is -1 and is the same as `LayoutDirection.UNDEFINED` but the symbol isn't available.
   protected int mLayoutDirection = UNSET;
@@ -205,6 +214,9 @@ public class TextAttributeProps {
         case TA_KEY_ACCESSIBILITY_ROLE:
           result.setAccessibilityRole(entry.getStringValue());
           break;
+        case TA_KEY_TEXT_CODE_BLOCK:
+          result.setTextCodeBlock(entry.getMapBufferValue());
+          break;
       }
     }
 
@@ -246,6 +258,7 @@ public class TextAttributeProps {
     result.setTextTransform(getStringProp(props, PROP_TEXT_TRANSFORM));
     result.setLayoutDirection(getStringProp(props, ViewProps.LAYOUT_DIRECTION));
     result.setAccessibilityRole(getStringProp(props, ViewProps.ACCESSIBILITY_ROLE));
+    result.setTextCodeBlock(getReadableMapProp(props, ViewProps.TEXT_CODE_BLOCK));
     return result;
   }
 
@@ -296,6 +309,15 @@ public class TextAttributeProps {
   private static String getStringProp(ReactStylesDiffMap mProps, String name) {
     if (mProps.hasKey(name)) {
       return mProps.getString(name);
+    } else {
+      return null;
+    }
+  }
+
+  private static ReadableMap getReadableMapProp(
+      ReactStylesDiffMap mProps, String name) {
+    if (mProps.hasKey(name)) {
+      return mProps.getMap(name);
     } else {
       return null;
     }
@@ -571,6 +593,39 @@ public class TextAttributeProps {
 
   private void setLayoutDirection(@Nullable String layoutDirection) {
     mLayoutDirection = getLayoutDirection(layoutDirection);
+  }
+
+  public ReadableMap getTextCodeBlock() {
+    return mTextCodeBlock;
+  }
+
+  private void setTextCodeBlock(@Nullable MapBuffer textCodeBlock) {
+    Iterator<MapBuffer.Entry> iterator = textCodeBlock.iterator();
+    WritableMap result = new WritableNativeMap();
+
+    while (iterator.hasNext()) {
+      MapBuffer.Entry entry = iterator.next();
+      switch (entry.getKey()) {
+        case TCB_KEY_BACKGROUND_COLOR:
+          result.putString("backgroundColor", entry.getStringValue());
+          break;
+        case TCB_KEY_BORDER_COLOR:
+          result.putString("borderColor", entry.getStringValue());
+          break;
+        case TCB_KEY_BORDER_RADIUS:
+          result.putInt("borderRadius", entry.getIntValue());
+          break;
+        case TCB_KEY_BORDER_WIDTH:
+          result.putInt("borderWidth", entry.getIntValue());
+          break;
+      }
+    }
+
+    mTextCodeBlock = result;
+  }
+
+  private void setTextCodeBlock(ReadableMap textCodeBlock) {
+    mTextCodeBlock = textCodeBlock;
   }
 
   private void setTextShadowRadius(float textShadowRadius) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -93,7 +93,7 @@ public class TextAttributeProps {
   protected float mLineHeightInput = UNSET;
   protected float mLetterSpacingInput = Float.NaN;
   protected int mTextAlign = Gravity.NO_GRAVITY;
-  protected ReadableMap mTextCodeBlock;
+  protected ReadableMap mTextCodeBlockStyle;
 
   // `UNSET` is -1 and is the same as `LayoutDirection.UNDEFINED` but the symbol isn't available.
   protected int mLayoutDirection = UNSET;
@@ -215,7 +215,7 @@ public class TextAttributeProps {
           result.setAccessibilityRole(entry.getStringValue());
           break;
         case TA_KEY_TEXT_CODE_BLOCK:
-          result.setTextCodeBlock(entry.getMapBufferValue());
+          result.setTextCodeBlockStyle(entry.getMapBufferValue());
           break;
       }
     }
@@ -258,7 +258,7 @@ public class TextAttributeProps {
     result.setTextTransform(getStringProp(props, PROP_TEXT_TRANSFORM));
     result.setLayoutDirection(getStringProp(props, ViewProps.LAYOUT_DIRECTION));
     result.setAccessibilityRole(getStringProp(props, ViewProps.ACCESSIBILITY_ROLE));
-    result.setTextCodeBlock(getReadableMapProp(props, ViewProps.TEXT_CODE_BLOCK));
+    result.setTextCodeBlockStyle(getReadableMapProp(props, ViewProps.TEXT_CODE_BLOCK));
     return result;
   }
 
@@ -595,12 +595,12 @@ public class TextAttributeProps {
     mLayoutDirection = getLayoutDirection(layoutDirection);
   }
 
-  public ReadableMap getTextCodeBlock() {
-    return mTextCodeBlock;
+  public ReadableMap getTextCodeBlockStyle() {
+    return mTextCodeBlockStyle;
   }
 
-  private void setTextCodeBlock(@Nullable MapBuffer textCodeBlock) {
-    Iterator<MapBuffer.Entry> iterator = textCodeBlock.iterator();
+  private void setTextCodeBlockStyle(@Nullable MapBuffer textCodeBlockStyle) {
+    Iterator<MapBuffer.Entry> iterator = textCodeBlockStyle.iterator();
     WritableMap result = new WritableNativeMap();
 
     while (iterator.hasNext()) {
@@ -621,11 +621,11 @@ public class TextAttributeProps {
       }
     }
 
-    mTextCodeBlock = result;
+    mTextCodeBlockStyle = result;
   }
 
-  private void setTextCodeBlock(ReadableMap textCodeBlock) {
-    mTextCodeBlock = textCodeBlock;
+  private void setTextCodeBlockStyle(ReadableMap textCodeBlockStyle) {
+    mTextCodeBlockStyle = textCodeBlockStyle;
   }
 
   private void setTextShadowRadius(float textShadowRadius) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
@@ -30,7 +30,7 @@ public class TextAttributes {
   private float mMaxFontSizeMultiplier = Float.NaN;
   private float mHeightOfTallestInlineViewOrImage = Float.NaN;
   private TextTransform mTextTransform = TextTransform.UNSET;
-  private ReadableMap mTextCodeBlock;
+  private ReadableMap mTextCodeBlockStyle;
 
   public TextAttributes() {}
 
@@ -55,7 +55,7 @@ public class TextAttributes {
             : mHeightOfTallestInlineViewOrImage;
     result.mTextTransform =
         child.mTextTransform != TextTransform.UNSET ? child.mTextTransform : mTextTransform;
-    result.mTextCodeBlock = child.mTextCodeBlock;
+    result.mTextCodeBlockStyle = child.mTextCodeBlockStyle;
 
     return result;
   }
@@ -176,12 +176,12 @@ public class TextAttributes {
         : DEFAULT_MAX_FONT_SIZE_MULTIPLIER;
   }
 
-  public ReadableMap getTextCodeBlock() {
-    return mTextCodeBlock;
+  public ReadableMap getTextCodeBlockStyle() {
+    return mTextCodeBlockStyle;
   }
 
-  public void setTextCodeBlock(ReadableMap textCodeBlock) {
-    mTextCodeBlock = textCodeBlock;
+  public void setTextCodeBlockStyle(ReadableMap textCodeBlockStyle) {
+    mTextCodeBlockStyle = textCodeBlockStyle;
   }
 
   public String toString() {
@@ -208,8 +208,8 @@ public class TextAttributes {
         + getMaxFontSizeMultiplier()
         + "\n  getEffectiveMaxFontSizeMultiplier(): "
         + getEffectiveMaxFontSizeMultiplier()
-        + "\n  getTextCodeBlock(): "
-        + getTextCodeBlock()
+        + "\n  getTextCodeBlockStyle(): "
+        + getTextCodeBlockStyle()
         + "\n}");
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
@@ -10,6 +10,7 @@ package com.facebook.react.views.text;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ViewDefaults;
+import com.facebook.react.bridge.ReadableMap;
 
 /*
  * Currently, TextAttributes consists of a subset of text props that need to be passed from parent
@@ -29,6 +30,7 @@ public class TextAttributes {
   private float mMaxFontSizeMultiplier = Float.NaN;
   private float mHeightOfTallestInlineViewOrImage = Float.NaN;
   private TextTransform mTextTransform = TextTransform.UNSET;
+  private ReadableMap mTextCodeBlock;
 
   public TextAttributes() {}
 
@@ -53,6 +55,7 @@ public class TextAttributes {
             : mHeightOfTallestInlineViewOrImage;
     result.mTextTransform =
         child.mTextTransform != TextTransform.UNSET ? child.mTextTransform : mTextTransform;
+    result.mTextCodeBlock = child.mTextCodeBlock;
 
     return result;
   }
@@ -173,6 +176,14 @@ public class TextAttributes {
         : DEFAULT_MAX_FONT_SIZE_MULTIPLIER;
   }
 
+  public ReadableMap getTextCodeBlock() {
+    return mTextCodeBlock;
+  }
+
+  public void setTextCodeBlock(ReadableMap textCodeBlock) {
+    mTextCodeBlock = textCodeBlock;
+  }
+
   public String toString() {
     return ("TextAttributes {"
         + "\n  getAllowFontScaling(): "
@@ -197,6 +208,8 @@ public class TextAttributes {
         + getMaxFontSizeMultiplier()
         + "\n  getEffectiveMaxFontSizeMultiplier(): "
         + getEffectiveMaxFontSizeMultiplier()
+        + "\n  getTextCodeBlock(): "
+        + getTextCodeBlock()
         + "\n}");
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -180,6 +180,9 @@ public class TextLayoutManager {
               new SetSpanOperation(
                   start, end, new CustomLineHeightSpan(textAttributes.getEffectiveLineHeight())));
         }
+        if (textAttributes.getTextCodeBlock() != null) {
+          ops.add(new SetSpanOperation(start, end, new ReactInlineBorderSpan(textAttributes.mFontSize, start, end, textAttributes.getTextCodeBlock())));
+        }
 
         ops.add(new SetSpanOperation(start, end, new ReactTagSpan(reactTag)));
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -180,8 +180,8 @@ public class TextLayoutManager {
               new SetSpanOperation(
                   start, end, new CustomLineHeightSpan(textAttributes.getEffectiveLineHeight())));
         }
-        if (textAttributes.getTextCodeBlock() != null) {
-          ops.add(new SetSpanOperation(start, end, new ReactInlineBorderSpan(textAttributes.mFontSize, start, end, textAttributes.getTextCodeBlock())));
+        if (textAttributes.getTextCodeBlockStyle() != null) {
+          ops.add(new SetSpanOperation(start, end, new ReactInlineBorderSpan(textAttributes.mFontSize, start, end, textAttributes.getTextCodeBlockStyle())));
         }
 
         ops.add(new SetSpanOperation(start, end, new ReactTagSpan(reactTag)));

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -196,8 +196,8 @@ public class TextLayoutManagerMapBuffer {
               new SetSpanOperation(
                   start, end, new CustomLineHeightSpan(textAttributes.getEffectiveLineHeight())));
         }
-        if (textAttributes.getTextCodeBlock() != null) {
-          ops.add(new SetSpanOperation(start, end, new ReactInlineBorderSpan(textAttributes.mFontSize, start, end, textAttributes.getTextCodeBlock())));
+        if (textAttributes.getTextCodeBlockStyle() != null) {
+          ops.add(new SetSpanOperation(start, end, new ReactInlineBorderSpan(textAttributes.mFontSize, start, end, textAttributes.getTextCodeBlockStyle())));
         }
 
         ops.add(new SetSpanOperation(start, end, new ReactTagSpan(reactTag)));

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -196,6 +196,9 @@ public class TextLayoutManagerMapBuffer {
               new SetSpanOperation(
                   start, end, new CustomLineHeightSpan(textAttributes.getEffectiveLineHeight())));
         }
+        if (textAttributes.getTextCodeBlock() != null) {
+          ops.add(new SetSpanOperation(start, end, new ReactInlineBorderSpan(textAttributes.mFontSize, start, end, textAttributes.getTextCodeBlock())));
+        }
 
         ops.add(new SetSpanOperation(start, end, new ReactTagSpan(reactTag)));
       }

--- a/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -101,6 +101,9 @@ void TextAttributes::apply(TextAttributes textAttributes) {
   accessibilityRole = textAttributes.accessibilityRole.has_value()
       ? textAttributes.accessibilityRole
       : accessibilityRole;
+  textCodeBlock = textAttributes.textCodeBlock.has_value()
+      ? textAttributes.textCodeBlock
+      : textCodeBlock;
 }
 
 #pragma mark - Operators
@@ -126,6 +129,7 @@ bool TextAttributes::operator==(const TextAttributes &rhs) const {
              isHighlighted,
              layoutDirection,
              accessibilityRole,
+             textCodeBlock,
              textTransform) ==
       std::tie(
              rhs.foregroundColor,
@@ -147,6 +151,7 @@ bool TextAttributes::operator==(const TextAttributes &rhs) const {
              rhs.isHighlighted,
              rhs.layoutDirection,
              rhs.accessibilityRole,
+             rhs.textCodeBlock,
              rhs.textTransform) &&
       floatEquality(opacity, rhs.opacity) &&
       floatEquality(fontSize, rhs.fontSize) &&
@@ -215,6 +220,7 @@ SharedDebugStringConvertibleList TextAttributes::getDebugProps() const {
       debugStringConvertibleItem("isHighlighted", isHighlighted),
       debugStringConvertibleItem("layoutDirection", layoutDirection),
       debugStringConvertibleItem("accessibilityRole", accessibilityRole),
+      debugStringConvertibleItem("textCodeBlock", textCodeBlock),
   };
 }
 #endif

--- a/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -101,9 +101,9 @@ void TextAttributes::apply(TextAttributes textAttributes) {
   accessibilityRole = textAttributes.accessibilityRole.has_value()
       ? textAttributes.accessibilityRole
       : accessibilityRole;
-  textCodeBlock = textAttributes.textCodeBlock.has_value()
-      ? textAttributes.textCodeBlock
-      : textCodeBlock;
+  textCodeBlockStyle = textAttributes.textCodeBlockStyle.has_value()
+      ? textAttributes.textCodeBlockStyle
+      : textCodeBlockStyle;
 }
 
 #pragma mark - Operators
@@ -129,7 +129,7 @@ bool TextAttributes::operator==(const TextAttributes &rhs) const {
              isHighlighted,
              layoutDirection,
              accessibilityRole,
-             textCodeBlock,
+             textCodeBlockStyle,
              textTransform) ==
       std::tie(
              rhs.foregroundColor,
@@ -151,7 +151,7 @@ bool TextAttributes::operator==(const TextAttributes &rhs) const {
              rhs.isHighlighted,
              rhs.layoutDirection,
              rhs.accessibilityRole,
-             rhs.textCodeBlock,
+             rhs.textCodeBlockStyle,
              rhs.textTransform) &&
       floatEquality(opacity, rhs.opacity) &&
       floatEquality(fontSize, rhs.fontSize) &&
@@ -220,7 +220,7 @@ SharedDebugStringConvertibleList TextAttributes::getDebugProps() const {
       debugStringConvertibleItem("isHighlighted", isHighlighted),
       debugStringConvertibleItem("layoutDirection", layoutDirection),
       debugStringConvertibleItem("accessibilityRole", accessibilityRole),
-      debugStringConvertibleItem("textCodeBlock", textCodeBlock),
+      debugStringConvertibleItem("textCodeBlockStyle", textCodeBlockStyle),
   };
 }
 #endif

--- a/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -80,6 +80,7 @@ class TextAttributes : public DebugStringConvertible {
   // construction.
   std::optional<LayoutDirection> layoutDirection{};
   std::optional<AccessibilityRole> accessibilityRole{};
+  std::optional<TextCodeBlockStruct> textCodeBlock{};
 
 #pragma mark - Operations
 

--- a/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -80,7 +80,7 @@ class TextAttributes : public DebugStringConvertible {
   // construction.
   std::optional<LayoutDirection> layoutDirection{};
   std::optional<AccessibilityRole> accessibilityRole{};
-  std::optional<TextCodeBlockStruct> textCodeBlock{};
+  std::optional<TextCodeBlockStyleStruct> textCodeBlockStyle{};
 
 #pragma mark - Operations
 

--- a/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -281,17 +281,17 @@ inline void fromRawValue(
   result = FontStyle::Normal;
 }
 
-inline std::string toString(const TextCodeBlockStruct &textCodeBlockStruct) {
-  return "{backgroundColor: " + folly::to<std::string>(textCodeBlockStruct.backgroundColor) +
-      ", borderRadius: " + folly::to<std::string>(textCodeBlockStruct.borderRadius) +
-      ", borderWidth: " + folly::to<std::string>(textCodeBlockStruct.borderWidth) +
-      ", borderColor: " + folly::to<std::string>(textCodeBlockStruct.borderColor) + "}";
+inline std::string toString(const TextCodeBlockStyleStruct &textCodeBlockStyleStruct) {
+  return "{backgroundColor: " + folly::to<std::string>(textCodeBlockStyleStruct.backgroundColor) +
+      ", borderRadius: " + folly::to<std::string>(textCodeBlockStyleStruct.borderRadius) +
+      ", borderWidth: " + folly::to<std::string>(textCodeBlockStyleStruct.borderWidth) +
+      ", borderColor: " + folly::to<std::string>(textCodeBlockStyleStruct.borderColor) + "}";
 }
 
 inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
-    TextCodeBlockStruct &result) {
+    TextCodeBlockStyleStruct &result) {
   auto map = (butter::map<std::string, RawValue>)value;
 
   auto backgroundColor = map.find("backgroundColor");
@@ -946,25 +946,25 @@ inline void fromRawValue(
   }
 }
 
-inline folly::dynamic toDynamic(const TextCodeBlockStruct &textCodeBlockStruct) {
-  auto _textCodeBlockStruct = folly::dynamic::object();
-  if (!textCodeBlockStruct.backgroundColor.empty()) {
-    _textCodeBlockStruct(
-        "backgroundColor", toString(textCodeBlockStruct.backgroundColor));
+inline folly::dynamic toDynamic(const TextCodeBlockStyleStruct &textCodeBlockStyleStruct) {
+  auto _textCodeBlockStyleStruct = folly::dynamic::object();
+  if (!textCodeBlockStyleStruct.backgroundColor.empty()) {
+    _textCodeBlockStyleStruct(
+        "backgroundColor", toString(textCodeBlockStyleStruct.backgroundColor));
   }
-  if (!textCodeBlockStruct.borderColor.empty()) {
-    _textCodeBlockStruct(
-        "borderColor", toString(textCodeBlockStruct.borderColor));
+  if (!textCodeBlockStyleStruct.borderColor.empty()) {
+    _textCodeBlockStyleStruct(
+        "borderColor", toString(textCodeBlockStyleStruct.borderColor));
   }
-  if (!std::isnan(textCodeBlockStruct.borderRadius)) {
-    _textCodeBlockStruct(
-        "borderRadius", textCodeBlockStruct.borderRadius);
+  if (!std::isnan(textCodeBlockStyleStruct.borderRadius)) {
+    _textCodeBlockStyleStruct(
+        "borderRadius", textCodeBlockStyleStruct.borderRadius);
   }
-  if (!std::isnan(textCodeBlockStruct.borderWidth)) {
-    _textCodeBlockStruct(
-        "borderWidth", textCodeBlockStruct.borderWidth);
+  if (!std::isnan(textCodeBlockStyleStruct.borderWidth)) {
+    _textCodeBlockStyleStruct(
+        "borderWidth", textCodeBlockStyleStruct.borderWidth);
   }
-  return _textCodeBlockStruct;
+  return _textCodeBlockStyleStruct;
 }
 
 inline std::string toString(AttributedString::Range const &range) {
@@ -979,19 +979,19 @@ constexpr static MapBuffer::Key TCB_KEY_BORDER_COLOR = 1;
 constexpr static MapBuffer::Key TCB_KEY_BORDER_RADIUS = 2;
 constexpr static MapBuffer::Key TCB_KEY_BORDER_WIDTH = 3;
 
-inline MapBuffer toMapBuffer(const TextCodeBlockStruct &textCodeBlockStruct) {
+inline MapBuffer toMapBuffer(const TextCodeBlockStyleStruct &textCodeBlockStyleStruct) {
   auto builder = MapBufferBuilder();
-  if (!textCodeBlockStruct.backgroundColor.empty()) {
-    builder.putString(TCB_KEY_BACKGROUND_COLOR, textCodeBlockStruct.backgroundColor);
+  if (!textCodeBlockStyleStruct.backgroundColor.empty()) {
+    builder.putString(TCB_KEY_BACKGROUND_COLOR, textCodeBlockStyleStruct.backgroundColor);
   }
-  if (!textCodeBlockStruct.borderColor.empty()) {
-    builder.putString(TCB_KEY_BORDER_COLOR, textCodeBlockStruct.borderColor);
+  if (!textCodeBlockStyleStruct.borderColor.empty()) {
+    builder.putString(TCB_KEY_BORDER_COLOR, textCodeBlockStyleStruct.borderColor);
   }
-  if (!std::isnan(textCodeBlockStruct.borderRadius)) {
-    builder.putInt(TCB_KEY_BORDER_RADIUS, textCodeBlockStruct.borderRadius);
+  if (!std::isnan(textCodeBlockStyleStruct.borderRadius)) {
+    builder.putInt(TCB_KEY_BORDER_RADIUS, textCodeBlockStyleStruct.borderRadius);
   }
-  if (!std::isnan(textCodeBlockStruct.borderWidth)) {
-    builder.putInt(TCB_KEY_BORDER_WIDTH, textCodeBlockStruct.borderWidth);
+  if (!std::isnan(textCodeBlockStyleStruct.borderWidth)) {
+    builder.putInt(TCB_KEY_BORDER_WIDTH, textCodeBlockStyleStruct.borderWidth);
   }
   return builder.build();
 }
@@ -1122,9 +1122,9 @@ inline folly::dynamic toDynamic(const TextAttributes &textAttributes) {
     _textAttributes(
         "accessibilityRole", toString(*textAttributes.accessibilityRole));
   }
-  if (textAttributes.textCodeBlock.has_value()) {
+  if (textAttributes.textCodeBlockStyle.has_value()) {
     _textAttributes(
-        "textCodeBlock", toDynamic(*textAttributes.textCodeBlock));
+        "textCodeBlockStyle", toDynamic(*textAttributes.textCodeBlockStyle));
   }
   return _textAttributes;
 }
@@ -1348,9 +1348,9 @@ inline MapBuffer toMapBuffer(const TextAttributes &textAttributes) {
     builder.putString(
         TA_KEY_ACCESSIBILITY_ROLE, toString(*textAttributes.accessibilityRole));
   }
-  if (textAttributes.textCodeBlock.has_value()) {
+  if (textAttributes.textCodeBlockStyle.has_value()) {
     builder.putMapBuffer(
-        TA_KEY_TEXT_CODE_BLOCK, toMapBuffer(*textAttributes.textCodeBlock));
+        TA_KEY_TEXT_CODE_BLOCK, toMapBuffer(*textAttributes.textCodeBlockStyle));
   }
   return builder.build();
 }

--- a/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -281,6 +281,48 @@ inline void fromRawValue(
   result = FontStyle::Normal;
 }
 
+inline std::string toString(const TextCodeBlockStruct &textCodeBlockStruct) {
+  return "{backgroundColor: " + folly::to<std::string>(textCodeBlockStruct.backgroundColor) +
+      ", borderRadius: " + folly::to<std::string>(textCodeBlockStruct.borderRadius) +
+      ", borderWidth: " + folly::to<std::string>(textCodeBlockStruct.borderWidth) +
+      ", borderColor: " + folly::to<std::string>(textCodeBlockStruct.borderColor) + "}";
+}
+
+inline void fromRawValue(
+    const PropsParserContext &context,
+    const RawValue &value,
+    TextCodeBlockStruct &result) {
+  auto map = (butter::map<std::string, RawValue>)value;
+
+  auto backgroundColor = map.find("backgroundColor");
+  if (backgroundColor != map.end()) {
+    if (backgroundColor->second.hasType<std::string>()) {
+      result.backgroundColor = (std::string)backgroundColor->second;
+    }
+  }
+
+  auto borderColor = map.find("borderColor");
+  if (borderColor != map.end()) {
+    if (borderColor->second.hasType<std::string>()) {
+      result.borderColor = (std::string)borderColor->second;
+    }
+  }
+
+  auto borderRadius = map.find("borderRadius");
+  if (borderRadius != map.end()) {
+    if (borderRadius->second.hasType<int>()) {
+      result.borderRadius = (int)borderRadius->second;
+    }
+  }
+
+  auto borderWidth = map.find("borderWidth");
+  if (borderWidth != map.end()) {
+    if (borderWidth->second.hasType<int>()) {
+      result.borderWidth = (int)borderWidth->second;
+    }
+  }
+}
+
 inline std::string toString(const FontStyle &fontStyle) {
   switch (fontStyle) {
     case FontStyle::Normal:
@@ -904,12 +946,55 @@ inline void fromRawValue(
   }
 }
 
+inline folly::dynamic toDynamic(const TextCodeBlockStruct &textCodeBlockStruct) {
+  auto _textCodeBlockStruct = folly::dynamic::object();
+  if (!textCodeBlockStruct.backgroundColor.empty()) {
+    _textCodeBlockStruct(
+        "backgroundColor", toString(textCodeBlockStruct.backgroundColor));
+  }
+  if (!textCodeBlockStruct.borderColor.empty()) {
+    _textCodeBlockStruct(
+        "borderColor", toString(textCodeBlockStruct.borderColor));
+  }
+  if (!std::isnan(textCodeBlockStruct.borderRadius)) {
+    _textCodeBlockStruct(
+        "borderRadius", textCodeBlockStruct.borderRadius);
+  }
+  if (!std::isnan(textCodeBlockStruct.borderWidth)) {
+    _textCodeBlockStruct(
+        "borderWidth", textCodeBlockStruct.borderWidth);
+  }
+  return _textCodeBlockStruct;
+}
+
 inline std::string toString(AttributedString::Range const &range) {
   return "{location: " + folly::to<std::string>(range.location) +
       ", length: " + folly::to<std::string>(range.length) + "}";
 }
 
 #ifdef ANDROID
+
+constexpr static MapBuffer::Key TCB_KEY_BACKGROUND_COLOR = 0;
+constexpr static MapBuffer::Key TCB_KEY_BORDER_COLOR = 1;
+constexpr static MapBuffer::Key TCB_KEY_BORDER_RADIUS = 2;
+constexpr static MapBuffer::Key TCB_KEY_BORDER_WIDTH = 3;
+
+inline MapBuffer toMapBuffer(const TextCodeBlockStruct &textCodeBlockStruct) {
+  auto builder = MapBufferBuilder();
+  if (!textCodeBlockStruct.backgroundColor.empty()) {
+    builder.putString(TCB_KEY_BACKGROUND_COLOR, textCodeBlockStruct.backgroundColor);
+  }
+  if (!textCodeBlockStruct.borderColor.empty()) {
+    builder.putString(TCB_KEY_BORDER_COLOR, textCodeBlockStruct.borderColor);
+  }
+  if (!std::isnan(textCodeBlockStruct.borderRadius)) {
+    builder.putInt(TCB_KEY_BORDER_RADIUS, textCodeBlockStruct.borderRadius);
+  }
+  if (!std::isnan(textCodeBlockStruct.borderWidth)) {
+    builder.putInt(TCB_KEY_BORDER_WIDTH, textCodeBlockStruct.borderWidth);
+  }
+  return builder.build();
+}
 
 inline folly::dynamic toDynamic(
     const ParagraphAttributes &paragraphAttributes) {
@@ -1037,6 +1122,10 @@ inline folly::dynamic toDynamic(const TextAttributes &textAttributes) {
     _textAttributes(
         "accessibilityRole", toString(*textAttributes.accessibilityRole));
   }
+  if (textAttributes.textCodeBlock.has_value()) {
+    _textAttributes(
+        "textCodeBlock", toDynamic(*textAttributes.textCodeBlock));
+  }
   return _textAttributes;
 }
 
@@ -1111,6 +1200,8 @@ constexpr static MapBuffer::Key TA_KEY_IS_HIGHLIGHTED = 20;
 constexpr static MapBuffer::Key TA_KEY_LAYOUT_DIRECTION = 21;
 constexpr static MapBuffer::Key TA_KEY_ACCESSIBILITY_ROLE = 22;
 constexpr static MapBuffer::Key TA_KEY_LINE_BREAK_STRATEGY = 23;
+
+constexpr static MapBuffer::Key TA_KEY_TEXT_CODE_BLOCK = 30;
 
 // constants for ParagraphAttributes serialization
 constexpr static MapBuffer::Key PA_KEY_MAX_NUMBER_OF_LINES = 0;
@@ -1256,6 +1347,10 @@ inline MapBuffer toMapBuffer(const TextAttributes &textAttributes) {
   if (textAttributes.accessibilityRole.has_value()) {
     builder.putString(
         TA_KEY_ACCESSIBILITY_ROLE, toString(*textAttributes.accessibilityRole));
+  }
+  if (textAttributes.textCodeBlock.has_value()) {
+    builder.putMapBuffer(
+        TA_KEY_TEXT_CODE_BLOCK, toMapBuffer(*textAttributes.textCodeBlock));
   }
   return builder.build();
 }

--- a/ReactCommon/react/renderer/attributedstring/primitives.h
+++ b/ReactCommon/react/renderer/attributedstring/primitives.h
@@ -137,6 +137,25 @@ enum class AccessibilityRole {
   Toolbar,
 };
 
+struct TextCodeBlockStruct {
+  std::string backgroundColor;
+  std::string borderColor;
+  int borderRadius;
+  int borderWidth;
+};
+
+inline bool operator==(
+    const TextCodeBlockStruct &lhs,
+    const TextCodeBlockStruct &rhs) {
+  return false;
+}
+
+inline bool operator!=(
+    const TextCodeBlockStruct &lhs,
+    const TextCodeBlockStruct &rhs) {
+  return !(lhs == rhs);
+}
+
 enum class TextTransform {
   None,
   Uppercase,
@@ -222,6 +241,19 @@ template <>
 struct hash<facebook::react::TextBreakStrategy> {
   size_t operator()(const facebook::react::TextBreakStrategy &v) const {
     return hash<int>()(static_cast<int>(v));
+  }
+};
+
+template <>
+struct hash<facebook::react::TextCodeBlockStruct> {
+  size_t operator()(
+      const facebook::react::TextCodeBlockStruct &textCodeBlockStruct) const {
+    return folly::hash::hash_combine(
+        textCodeBlockStruct.backgroundColor,
+        textCodeBlockStruct.borderColor,
+        textCodeBlockStruct.borderRadius,
+        textCodeBlockStruct.borderWidth
+    );
   }
 };
 

--- a/ReactCommon/react/renderer/attributedstring/primitives.h
+++ b/ReactCommon/react/renderer/attributedstring/primitives.h
@@ -137,7 +137,7 @@ enum class AccessibilityRole {
   Toolbar,
 };
 
-struct TextCodeBlockStruct {
+struct TextCodeBlockStyleStruct {
   std::string backgroundColor;
   std::string borderColor;
   int borderRadius;
@@ -145,14 +145,14 @@ struct TextCodeBlockStruct {
 };
 
 inline bool operator==(
-    const TextCodeBlockStruct &lhs,
-    const TextCodeBlockStruct &rhs) {
+    const TextCodeBlockStyleStruct &lhs,
+    const TextCodeBlockStyleStruct &rhs) {
   return false;
 }
 
 inline bool operator!=(
-    const TextCodeBlockStruct &lhs,
-    const TextCodeBlockStruct &rhs) {
+    const TextCodeBlockStyleStruct &lhs,
+    const TextCodeBlockStyleStruct &rhs) {
   return !(lhs == rhs);
 }
 
@@ -245,14 +245,14 @@ struct hash<facebook::react::TextBreakStrategy> {
 };
 
 template <>
-struct hash<facebook::react::TextCodeBlockStruct> {
+struct hash<facebook::react::TextCodeBlockStyleStruct> {
   size_t operator()(
-      const facebook::react::TextCodeBlockStruct &textCodeBlockStruct) const {
+      const facebook::react::TextCodeBlockStyleStruct &textCodeBlockStyleStruct) const {
     return folly::hash::hash_combine(
-        textCodeBlockStruct.backgroundColor,
-        textCodeBlockStruct.borderColor,
-        textCodeBlockStruct.borderRadius,
-        textCodeBlockStruct.borderWidth
+        textCodeBlockStyleStruct.backgroundColor,
+        textCodeBlockStyleStruct.borderColor,
+        textCodeBlockStyleStruct.borderRadius,
+        textCodeBlockStyleStruct.borderWidth
     );
   }
 };

--- a/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -196,6 +196,12 @@ static TextAttributes convertRawProp(
       "backgroundColor",
       sourceTextAttributes.backgroundColor,
       defaultTextAttributes.backgroundColor);
+  textAttributes.textCodeBlock = convertRawProp(
+      context,
+      rawProps,
+      "textCodeBlock",
+      sourceTextAttributes.textCodeBlock,
+      defaultTextAttributes.textCodeBlock);
 
   return textAttributes;
 }
@@ -297,6 +303,8 @@ void BaseTextProps::setProp(
         defaults, value, textAttributes, opacity, "opacity");
     REBUILD_FIELD_SWITCH_CASE(
         defaults, value, textAttributes, backgroundColor, "backgroundColor");
+    REBUILD_FIELD_SWITCH_CASE(
+        defaults, value, textAttributes, textCodeBlock, "textCodeBlock");
   }
 }
 

--- a/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -196,12 +196,12 @@ static TextAttributes convertRawProp(
       "backgroundColor",
       sourceTextAttributes.backgroundColor,
       defaultTextAttributes.backgroundColor);
-  textAttributes.textCodeBlock = convertRawProp(
+  textAttributes.textCodeBlockStyle = convertRawProp(
       context,
       rawProps,
-      "textCodeBlock",
-      sourceTextAttributes.textCodeBlock,
-      defaultTextAttributes.textCodeBlock);
+      "textCodeBlockStyle",
+      sourceTextAttributes.textCodeBlockStyle,
+      defaultTextAttributes.textCodeBlockStyle);
 
   return textAttributes;
 }
@@ -304,7 +304,7 @@ void BaseTextProps::setProp(
     REBUILD_FIELD_SWITCH_CASE(
         defaults, value, textAttributes, backgroundColor, "backgroundColor");
     REBUILD_FIELD_SWITCH_CASE(
-        defaults, value, textAttributes, textCodeBlock, "textCodeBlock");
+        defaults, value, textAttributes, textCodeBlockStyle, "textCodeBlockStyle");
   }
 }
 

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.h
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 NSString *const RCTAttributedStringIsHighlightedAttributeName = @"IsHighlighted";
 NSString *const RCTAttributedStringEventEmitterKey = @"EventEmitter";
 NSString *const RCTTextAttributesAccessibilityRoleAttributeName = @"AccessibilityRole";
-NSString *const RCTTextAttributesIsTextCodeBlockAttributeName = @"RCTTextAttributesIsTextCodeBlockAttributeName";
+NSString *const RCTTextAttributesIsTextCodeBlockStyleAttributeName = @"RCTTextAttributesIsTextCodeBlockStyleAttributeName";
 
 /*
  * Creates `NSTextAttributes` from given `facebook::react::TextAttributes`

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.h
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 NSString *const RCTAttributedStringIsHighlightedAttributeName = @"IsHighlighted";
 NSString *const RCTAttributedStringEventEmitterKey = @"EventEmitter";
 NSString *const RCTTextAttributesAccessibilityRoleAttributeName = @"AccessibilityRole";
+NSString *const RCTTextAttributesIsTextCodeBlockAttributeName = @"RCTTextAttributesIsTextCodeBlockAttributeName";
 
 /*
  * Creates `NSTextAttributes` from given `facebook::react::TextAttributes`

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.mm
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.mm
@@ -288,6 +288,18 @@ NSDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttributes(T
     attributes[RCTAttributedStringIsHighlightedAttributeName] = @YES;
   }
 
+  if (textAttributes.textCodeBlock) {
+    NSString *backgroundColor = [NSString stringWithCString:textAttributes.textCodeBlock.value().backgroundColor.c_str() encoding:NSUTF8StringEncoding];
+    NSString *borderColor = [NSString stringWithCString:textAttributes.textCodeBlock.value().borderColor.c_str() encoding:NSUTF8StringEncoding];
+
+    attributes[RCTTextAttributesIsTextCodeBlockAttributeName] = @{
+      @"backgroundColor": backgroundColor,
+      @"borderColor": borderColor,
+      @"borderWidth": @(textAttributes.textCodeBlock.value().borderWidth),
+      @"borderRadius": @(textAttributes.textCodeBlock.value().borderRadius),
+    };
+  }
+
   if (textAttributes.accessibilityRole.has_value()) {
     auto accessibilityRole = textAttributes.accessibilityRole.value();
     switch (accessibilityRole) {

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.mm
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTAttributedTextUtils.mm
@@ -288,15 +288,15 @@ NSDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttributes(T
     attributes[RCTAttributedStringIsHighlightedAttributeName] = @YES;
   }
 
-  if (textAttributes.textCodeBlock) {
-    NSString *backgroundColor = [NSString stringWithCString:textAttributes.textCodeBlock.value().backgroundColor.c_str() encoding:NSUTF8StringEncoding];
-    NSString *borderColor = [NSString stringWithCString:textAttributes.textCodeBlock.value().borderColor.c_str() encoding:NSUTF8StringEncoding];
+  if (textAttributes.textCodeBlockStyle) {
+    NSString *backgroundColor = [NSString stringWithCString:textAttributes.textCodeBlockStyle.value().backgroundColor.c_str() encoding:NSUTF8StringEncoding];
+    NSString *borderColor = [NSString stringWithCString:textAttributes.textCodeBlockStyle.value().borderColor.c_str() encoding:NSUTF8StringEncoding];
 
-    attributes[RCTTextAttributesIsTextCodeBlockAttributeName] = @{
+    attributes[RCTTextAttributesIsTextCodeBlockStyleAttributeName] = @{
       @"backgroundColor": backgroundColor,
       @"borderColor": borderColor,
-      @"borderWidth": @(textAttributes.textCodeBlock.value().borderWidth),
-      @"borderRadius": @(textAttributes.textCodeBlock.value().borderRadius),
+      @"borderWidth": @(textAttributes.textCodeBlockStyle.value().borderWidth),
+      @"borderRadius": @(textAttributes.textCodeBlockStyle.value().borderRadius),
     };
   }
 

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextLayoutManager.mm
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextLayoutManager.mm
@@ -9,6 +9,7 @@
 
 #import "NSTextStorage+FontScaling.h"
 #import "RCTAttributedTextUtils.h"
+#import "RCTTextCodeBlock.h"
 
 #import <React/RCTUtils.h>
 #import <react/utils/ManagedObjectWrapper.h>
@@ -182,7 +183,7 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
       : NSLineBreakByClipping;
   textContainer.maximumNumberOfLines = paragraphAttributes.maximumNumberOfLines;
 
-  NSLayoutManager *layoutManager = [NSLayoutManager new];
+  NSLayoutManager *layoutManager = [RCTTextCodeBlock new];
   layoutManager.usesFontLeading = NO;
   [layoutManager addTextContainer:textContainer];
 

--- a/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextLayoutManager.mm
+++ b/ReactCommon/react/renderer/textlayoutmanager/platform/ios/RCTTextLayoutManager.mm
@@ -9,7 +9,7 @@
 
 #import "NSTextStorage+FontScaling.h"
 #import "RCTAttributedTextUtils.h"
-#import "RCTTextCodeBlock.h"
+#import "RCTTextCodeBlockStyle.h"
 
 #import <React/RCTUtils.h>
 #import <react/utils/ManagedObjectWrapper.h>
@@ -183,7 +183,7 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
       : NSLineBreakByClipping;
   textContainer.maximumNumberOfLines = paragraphAttributes.maximumNumberOfLines;
 
-  NSLayoutManager *layoutManager = [RCTTextCodeBlock new];
+  NSLayoutManager *layoutManager = [RCTTextCodeBlockStyle new];
   layoutManager.usesFontLeading = NO;
   [layoutManager addTextContainer:textContainer];
 

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.71.1)
-  - FBReactNativeSpec (0.71.1):
+  - FBLazyVector (0.71.2-alpha.1)
+  - FBReactNativeSpec (0.71.2-alpha.1):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-Core (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-Core (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
   - Flipper (0.125.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
@@ -73,9 +73,9 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.71.1):
-    - hermes-engine/Pre-built (= 0.71.1)
-  - hermes-engine/Pre-built (0.71.1)
+  - hermes-engine (0.71.2):
+    - hermes-engine/Pre-built (= 0.71.2)
+  - hermes-engine/Pre-built (0.71.2)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.07.22.00):
@@ -100,26 +100,26 @@ PODS:
     - fmt (~> 6.2.1)
     - glog
     - libevent
-  - RCTRequired (0.71.1)
-  - RCTTypeSafety (0.71.1):
-    - FBLazyVector (= 0.71.1)
-    - RCTRequired (= 0.71.1)
-    - React-Core (= 0.71.1)
-  - React (0.71.1):
-    - React-Core (= 0.71.1)
-    - React-Core/DevSupport (= 0.71.1)
-    - React-Core/RCTWebSocket (= 0.71.1)
-    - React-RCTActionSheet (= 0.71.1)
-    - React-RCTAnimation (= 0.71.1)
-    - React-RCTBlob (= 0.71.1)
-    - React-RCTImage (= 0.71.1)
-    - React-RCTLinking (= 0.71.1)
-    - React-RCTNetwork (= 0.71.1)
-    - React-RCTSettings (= 0.71.1)
-    - React-RCTText (= 0.71.1)
-    - React-RCTVibration (= 0.71.1)
-  - React-callinvoker (0.71.1)
-  - React-Codegen (0.71.1):
+  - RCTRequired (0.71.2-alpha.1)
+  - RCTTypeSafety (0.71.2-alpha.1):
+    - FBLazyVector (= 0.71.2-alpha.1)
+    - RCTRequired (= 0.71.2-alpha.1)
+    - React-Core (= 0.71.2-alpha.1)
+  - React (0.71.2-alpha.1):
+    - React-Core (= 0.71.2-alpha.1)
+    - React-Core/DevSupport (= 0.71.2-alpha.1)
+    - React-Core/RCTWebSocket (= 0.71.2-alpha.1)
+    - React-RCTActionSheet (= 0.71.2-alpha.1)
+    - React-RCTAnimation (= 0.71.2-alpha.1)
+    - React-RCTBlob (= 0.71.2-alpha.1)
+    - React-RCTImage (= 0.71.2-alpha.1)
+    - React-RCTLinking (= 0.71.2-alpha.1)
+    - React-RCTNetwork (= 0.71.2-alpha.1)
+    - React-RCTSettings (= 0.71.2-alpha.1)
+    - React-RCTText (= 0.71.2-alpha.1)
+    - React-RCTVibration (= 0.71.2-alpha.1)
+  - React-callinvoker (0.71.2-alpha.1)
+  - React-Codegen (0.71.2-alpha.1):
     - FBReactNativeSpec
     - hermes-engine
     - RCT-Folly
@@ -132,617 +132,655 @@ PODS:
     - React-rncore
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.71.1):
+  - React-Core (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.1)
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-Core/Default (= 0.71.2-alpha.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.71.1):
+  - React-Core/CoreModulesHeaders (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/Default (0.71.1):
+  - React-Core/Default (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/DevSupport (0.71.1):
+  - React-Core/DevSupport (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.1)
-    - React-Core/RCTWebSocket (= 0.71.1)
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-jsinspector (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-Core/Default (= 0.71.2-alpha.1)
+    - React-Core/RCTWebSocket (= 0.71.2-alpha.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-jsinspector (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/RCTActionSheetHeaders (0.71.1):
+  - React-Core/RCTActionSheetHeaders (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.71.1):
+  - React-Core/RCTAnimationHeaders (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.71.1):
+  - React-Core/RCTBlobHeaders (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.71.1):
+  - React-Core/RCTImageHeaders (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.71.1):
+  - React-Core/RCTLinkingHeaders (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.71.1):
+  - React-Core/RCTNetworkHeaders (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.71.1):
+  - React-Core/RCTPushNotificationHeaders (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.71.1):
+  - React-Core/RCTSettingsHeaders (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.71.1):
+  - React-Core/RCTTextHeaders (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.71.1):
+  - React-Core/RCTVibrationHeaders (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.71.1):
+  - React-Core/RCTWebSocket (0.71.2-alpha.1):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.1)
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-perflogger (= 0.71.1)
+    - React-Core/Default (= 0.71.2-alpha.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-hermes
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
     - Yoga
-  - React-CoreModules (0.71.1):
+  - React-CoreModules (0.71.2-alpha.1):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.1)
-    - React-Codegen (= 0.71.1)
-    - React-Core/CoreModulesHeaders (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-RCTImage (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-cxxreact (0.71.1):
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-Codegen (= 0.71.2-alpha.1)
+    - React-Core/CoreModulesHeaders (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-RCTBlob
+    - React-RCTImage (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-cxxreact (0.71.2-alpha.1):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsinspector (= 0.71.1)
-    - React-logger (= 0.71.1)
-    - React-perflogger (= 0.71.1)
-    - React-runtimeexecutor (= 0.71.1)
-  - React-Fabric (0.71.1):
+    - React-callinvoker (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsinspector (= 0.71.2-alpha.1)
+    - React-logger (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
+    - React-runtimeexecutor (= 0.71.2-alpha.1)
+  - React-Fabric (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-Fabric/animations (= 0.71.1)
-    - React-Fabric/attributedstring (= 0.71.1)
-    - React-Fabric/butter (= 0.71.1)
-    - React-Fabric/componentregistry (= 0.71.1)
-    - React-Fabric/componentregistrynative (= 0.71.1)
-    - React-Fabric/components (= 0.71.1)
-    - React-Fabric/config (= 0.71.1)
-    - React-Fabric/core (= 0.71.1)
-    - React-Fabric/debug_core (= 0.71.1)
-    - React-Fabric/debug_renderer (= 0.71.1)
-    - React-Fabric/imagemanager (= 0.71.1)
-    - React-Fabric/leakchecker (= 0.71.1)
-    - React-Fabric/mapbuffer (= 0.71.1)
-    - React-Fabric/mounting (= 0.71.1)
-    - React-Fabric/runtimescheduler (= 0.71.1)
-    - React-Fabric/scheduler (= 0.71.1)
-    - React-Fabric/telemetry (= 0.71.1)
-    - React-Fabric/templateprocessor (= 0.71.1)
-    - React-Fabric/textlayoutmanager (= 0.71.1)
-    - React-Fabric/uimanager (= 0.71.1)
-    - React-Fabric/utils (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/animations (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-Fabric/animations (= 0.71.2-alpha.1)
+    - React-Fabric/attributedstring (= 0.71.2-alpha.1)
+    - React-Fabric/butter (= 0.71.2-alpha.1)
+    - React-Fabric/componentregistry (= 0.71.2-alpha.1)
+    - React-Fabric/componentregistrynative (= 0.71.2-alpha.1)
+    - React-Fabric/components (= 0.71.2-alpha.1)
+    - React-Fabric/config (= 0.71.2-alpha.1)
+    - React-Fabric/core (= 0.71.2-alpha.1)
+    - React-Fabric/debug_core (= 0.71.2-alpha.1)
+    - React-Fabric/debug_renderer (= 0.71.2-alpha.1)
+    - React-Fabric/imagemanager (= 0.71.2-alpha.1)
+    - React-Fabric/leakchecker (= 0.71.2-alpha.1)
+    - React-Fabric/mapbuffer (= 0.71.2-alpha.1)
+    - React-Fabric/mounting (= 0.71.2-alpha.1)
+    - React-Fabric/runtimescheduler (= 0.71.2-alpha.1)
+    - React-Fabric/scheduler (= 0.71.2-alpha.1)
+    - React-Fabric/telemetry (= 0.71.2-alpha.1)
+    - React-Fabric/templateprocessor (= 0.71.2-alpha.1)
+    - React-Fabric/textlayoutmanager (= 0.71.2-alpha.1)
+    - React-Fabric/uimanager (= 0.71.2-alpha.1)
+    - React-Fabric/utils (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/animations (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/attributedstring (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/attributedstring (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/butter (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/butter (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/componentregistry (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/componentregistry (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/componentregistrynative (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/componentregistrynative (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-Fabric/components/activityindicator (= 0.71.1)
-    - React-Fabric/components/image (= 0.71.1)
-    - React-Fabric/components/inputaccessory (= 0.71.1)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.71.1)
-    - React-Fabric/components/modal (= 0.71.1)
-    - React-Fabric/components/root (= 0.71.1)
-    - React-Fabric/components/safeareaview (= 0.71.1)
-    - React-Fabric/components/scrollview (= 0.71.1)
-    - React-Fabric/components/slider (= 0.71.1)
-    - React-Fabric/components/text (= 0.71.1)
-    - React-Fabric/components/textinput (= 0.71.1)
-    - React-Fabric/components/unimplementedview (= 0.71.1)
-    - React-Fabric/components/view (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components/activityindicator (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-Fabric/components/activityindicator (= 0.71.2-alpha.1)
+    - React-Fabric/components/image (= 0.71.2-alpha.1)
+    - React-Fabric/components/inputaccessory (= 0.71.2-alpha.1)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.71.2-alpha.1)
+    - React-Fabric/components/modal (= 0.71.2-alpha.1)
+    - React-Fabric/components/root (= 0.71.2-alpha.1)
+    - React-Fabric/components/safeareaview (= 0.71.2-alpha.1)
+    - React-Fabric/components/scrollview (= 0.71.2-alpha.1)
+    - React-Fabric/components/slider (= 0.71.2-alpha.1)
+    - React-Fabric/components/text (= 0.71.2-alpha.1)
+    - React-Fabric/components/textinput (= 0.71.2-alpha.1)
+    - React-Fabric/components/unimplementedview (= 0.71.2-alpha.1)
+    - React-Fabric/components/view (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components/activityindicator (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components/image (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components/image (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components/inputaccessory (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components/inputaccessory (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components/legacyviewmanagerinterop (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components/legacyviewmanagerinterop (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components/modal (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components/modal (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components/root (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components/root (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components/safeareaview (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components/safeareaview (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components/scrollview (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components/scrollview (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components/slider (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components/slider (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components/text (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components/text (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components/textinput (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components/textinput (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components/unimplementedview (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components/unimplementedview (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/components/view (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/components/view (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
     - Yoga
-  - React-Fabric/config (0.71.1):
+  - React-Fabric/config (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/core (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/core (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/debug_core (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/debug_core (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/debug_renderer (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/debug_renderer (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/imagemanager (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/imagemanager (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-RCTImage (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/leakchecker (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-RCTImage (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/leakchecker (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/mapbuffer (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/mapbuffer (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/mounting (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/mounting (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/runtimescheduler (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/runtimescheduler (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/scheduler (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/scheduler (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/telemetry (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/telemetry (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/templateprocessor (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/templateprocessor (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/textlayoutmanager (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/textlayoutmanager (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
     - React-Fabric/uimanager
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/uimanager (0.71.1):
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/uimanager (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-Fabric/utils (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-Fabric/utils (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.1)
-    - RCTTypeSafety (= 0.71.1)
-    - React-graphics (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-graphics (0.71.1):
+    - RCTRequired (= 0.71.2-alpha.1)
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-graphics (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-graphics (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.1)
-  - React-hermes (0.71.1):
+    - React-Core/Default (= 0.71.2-alpha.1)
+  - React-hermes (0.71.2-alpha.1):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - RCT-Folly/Futures (= 2021.07.22.00)
-    - React-cxxreact (= 0.71.1)
-    - React-jsiexecutor (= 0.71.1)
-    - React-jsinspector (= 0.71.1)
-    - React-perflogger (= 0.71.1)
-  - React-jsi (0.71.1):
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-jsi
+    - React-jsiexecutor (= 0.71.2-alpha.1)
+    - React-jsinspector (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
+  - React-jsi (0.71.2-alpha.1):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-  - React-jsiexecutor (0.71.1):
+  - React-jsiexecutor (0.71.2-alpha.1):
     - DoubleConversion
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-perflogger (= 0.71.1)
-  - React-jsinspector (0.71.1)
-  - React-logger (0.71.1):
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
+  - React-jsinspector (0.71.2-alpha.1)
+  - React-logger (0.71.2-alpha.1):
     - glog
-  - React-perflogger (0.71.1)
-  - React-RCTActionSheet (0.71.1):
-    - React-Core/RCTActionSheetHeaders (= 0.71.1)
-  - React-RCTAnimation (0.71.1):
+  - React-perflogger (0.71.2-alpha.1)
+  - React-RCTActionSheet (0.71.2-alpha.1):
+    - React-Core/RCTActionSheetHeaders (= 0.71.2-alpha.1)
+  - React-RCTAnimation (0.71.2-alpha.1):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.1)
-    - React-Codegen (= 0.71.1)
-    - React-Core/RCTAnimationHeaders (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-RCTAppDelegate (0.71.1):
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-Codegen (= 0.71.2-alpha.1)
+    - React-Core/RCTAnimationHeaders (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-RCTAppDelegate (0.71.2-alpha.1):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
     - ReactCommon/turbomodule/core
-  - React-RCTBlob (0.71.1):
+  - React-RCTBlob (0.71.2-alpha.1):
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.71.1)
-    - React-Core/RCTBlobHeaders (= 0.71.1)
-    - React-Core/RCTWebSocket (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-RCTNetwork (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-RCTFabric (0.71.1):
+    - React-Codegen (= 0.71.2-alpha.1)
+    - React-Core/RCTBlobHeaders (= 0.71.2-alpha.1)
+    - React-Core/RCTWebSocket (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-RCTNetwork (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-RCTFabric (0.71.2-alpha.1):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - React-Core (= 0.71.1)
-    - React-Fabric (= 0.71.1)
-    - React-RCTImage (= 0.71.1)
-  - React-RCTImage (0.71.1):
+    - React-Core (= 0.71.2-alpha.1)
+    - React-Fabric (= 0.71.2-alpha.1)
+    - React-RCTImage (= 0.71.2-alpha.1)
+  - React-RCTImage (0.71.2-alpha.1):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.1)
-    - React-Codegen (= 0.71.1)
-    - React-Core/RCTImageHeaders (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-RCTNetwork (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-RCTLinking (0.71.1):
-    - React-Codegen (= 0.71.1)
-    - React-Core/RCTLinkingHeaders (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-RCTNetwork (0.71.1):
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-Codegen (= 0.71.2-alpha.1)
+    - React-Core/RCTImageHeaders (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-RCTNetwork (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-RCTLinking (0.71.2-alpha.1):
+    - React-Codegen (= 0.71.2-alpha.1)
+    - React-Core/RCTLinkingHeaders (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-RCTNetwork (0.71.2-alpha.1):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.1)
-    - React-Codegen (= 0.71.1)
-    - React-Core/RCTNetworkHeaders (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-RCTPushNotification (0.71.1):
-    - RCTTypeSafety (= 0.71.1)
-    - React-Codegen (= 0.71.1)
-    - React-Core/RCTPushNotificationHeaders (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-RCTSettings (0.71.1):
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-Codegen (= 0.71.2-alpha.1)
+    - React-Core/RCTNetworkHeaders (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-RCTPushNotification (0.71.2-alpha.1):
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-Codegen (= 0.71.2-alpha.1)
+    - React-Core/RCTPushNotificationHeaders (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-RCTSettings (0.71.2-alpha.1):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.1)
-    - React-Codegen (= 0.71.1)
-    - React-Core/RCTSettingsHeaders (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-RCTTest (0.71.1):
+    - RCTTypeSafety (= 0.71.2-alpha.1)
+    - React-Codegen (= 0.71.2-alpha.1)
+    - React-Core/RCTSettingsHeaders (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-RCTTest (0.71.2-alpha.1):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core (= 0.71.1)
-    - React-CoreModules (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-RCTText (0.71.1):
-    - React-Core/RCTTextHeaders (= 0.71.1)
-  - React-RCTVibration (0.71.1):
+    - React-Core (= 0.71.2-alpha.1)
+    - React-CoreModules (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-RCTText (0.71.2-alpha.1):
+    - React-Core/RCTTextHeaders (= 0.71.2-alpha.1)
+  - React-RCTVibration (0.71.2-alpha.1):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.71.1)
-    - React-Core/RCTVibrationHeaders (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
-  - React-rncore (0.71.1)
-  - React-runtimeexecutor (0.71.1):
-    - React-jsi (= 0.71.1)
-  - ReactCommon/turbomodule/bridging (0.71.1):
+    - React-Codegen (= 0.71.2-alpha.1)
+    - React-Core/RCTVibrationHeaders (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
+  - React-rncore (0.71.2-alpha.1)
+  - React-runtimeexecutor (0.71.2-alpha.1):
+    - React-jsi (= 0.71.2-alpha.1)
+  - ReactCommon/turbomodule/bridging (0.71.2-alpha.1):
     - DoubleConversion
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.1)
-    - React-Core (= 0.71.1)
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-logger (= 0.71.1)
-    - React-perflogger (= 0.71.1)
-  - ReactCommon/turbomodule/core (0.71.1):
+    - React-callinvoker (= 0.71.2-alpha.1)
+    - React-Core (= 0.71.2-alpha.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-logger (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
+  - ReactCommon/turbomodule/core (0.71.2-alpha.1):
     - DoubleConversion
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.1)
-    - React-Core (= 0.71.1)
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-logger (= 0.71.1)
-    - React-perflogger (= 0.71.1)
-  - ReactCommon/turbomodule/samples (0.71.1):
+    - React-callinvoker (= 0.71.2-alpha.1)
+    - React-Core (= 0.71.2-alpha.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-logger (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
+  - ReactCommon/turbomodule/samples (0.71.2-alpha.1):
     - DoubleConversion
     - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.1)
-    - React-Core (= 0.71.1)
-    - React-cxxreact (= 0.71.1)
-    - React-jsi (= 0.71.1)
-    - React-logger (= 0.71.1)
-    - React-perflogger (= 0.71.1)
-    - ReactCommon/turbomodule/core (= 0.71.1)
+    - React-callinvoker (= 0.71.2-alpha.1)
+    - React-Core (= 0.71.2-alpha.1)
+    - React-cxxreact (= 0.71.2-alpha.1)
+    - React-jsi (= 0.71.2-alpha.1)
+    - React-logger (= 0.71.2-alpha.1)
+    - React-perflogger (= 0.71.2-alpha.1)
+    - ReactCommon/turbomodule/core (= 0.71.2-alpha.1)
   - ScreenshotManager (0.0.1):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
@@ -927,8 +965,8 @@ SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
-  FBLazyVector: ad72713385db5289b19f1ead07e8e4aa26dcb01d
-  FBReactNativeSpec: ca4085fea58242cacf87448d5e776e2f699591b1
+  FBLazyVector: af97b2beecd0e959ef294e1c4dbc9ca1866e4e46
+  FBReactNativeSpec: b1a87eff4c4b161b759ed0bc1fab31d7930fe324
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -940,45 +978,45 @@ SPEC CHECKSUMS:
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  hermes-engine: 922ccd744f50d9bfde09e9677bf0f3b562ea5fb9
+  hermes-engine: e6d490355acc3a6af335521f15e60d1bee1c86db
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
-  RCTRequired: fd4d923b964658aa0c4091a32c8b2004c6d9e3a6
-  RCTTypeSafety: c276d85975bde3d8448907235c70bf0da257adfd
-  React: e481a67971af1ce9639c9f746b753dd0e84ca108
-  React-callinvoker: 1051c04a94fa9d243786b86380606bad701a3b31
-  React-Codegen: 1e9399e01f77a4bc3e784df7fbd7ea63385c3b99
-  React-Core: 698fc3baecb80d511d987475a16d036cec6d287f
-  React-CoreModules: 59245305f41ff0adfeac334acc0594dea4585a7c
-  React-cxxreact: 49accd2954b0f532805dbcd1918fa6962f32f247
-  React-Fabric: 30982dc19c7511bedf1751b0a0c21a5b816e2a3e
-  React-graphics: beabc29b026e7472ced1482557effedd15a09cf1
-  React-hermes: d068733294581a085e95b6024e8d951b005e26d3
-  React-jsi: 122b9bce14f4c6c7cb58f28f87912cfe091885fa
-  React-jsiexecutor: 60cf272aababc5212410e4249d17cea14fc36caa
-  React-jsinspector: ff56004b0c974b688a6548c156d5830ad751ae07
-  React-logger: 60a0b5f8bed667ecf9e24fecca1f30d125de6d75
-  React-perflogger: ec8eef2a8f03ecfa6361c2c5fb9197ef4a29cc85
-  React-RCTActionSheet: a0c023b86cf4c862fa9c4eb0f6f91fbe878fb2de
-  React-RCTAnimation: 168d53718c74153947c0109f55900faa64d79439
-  React-RCTAppDelegate: a8efbab128b34aa07a9491c85a41401210b1bec5
-  React-RCTBlob: 9bcbfc893bfda9f6b2eb016329d38c0f6366d31a
-  React-RCTFabric: cec4e89720e8778aa132e5515be1af251d2e9b6a
-  React-RCTImage: 3fcd4570b4b0f1ac2f4b4b6308dba33ce66c5b50
-  React-RCTLinking: 1edb8e1bb3fc39bf9e13c63d6aaaa3f0c3d18683
-  React-RCTNetwork: 500a79e0e0f67678077df727fabba87a55c043e1
-  React-RCTPushNotification: bdda1fe98ca99051483ef916dcb48623ce19542c
-  React-RCTSettings: cc4414eb84ad756d619076c3999fecbf12896d6f
-  React-RCTTest: e20d4560688c9d6450d81f46e409e67484bb1820
-  React-RCTText: 2a34261f3da6e34f47a62154def657546ebfa5e1
-  React-RCTVibration: 49d531ec8498e0afa2c9b22c2205784372e3d4f3
-  React-rncore: 4d527c6e901fef2dee9456ecd180830378170013
-  React-runtimeexecutor: 311feb67600774723fe10eb8801d3138cae9ad67
-  ReactCommon: 03be76588338a27a88d103b35c3c44a3fd43d136
+  RCTRequired: c388f0961c88240455d10e5f9a14e01368d62c9f
+  RCTTypeSafety: 48106d0a03e27916d9866c50a221953b9e52fb7c
+  React: 35648f4574a584062a1efe28a45fca3556c09ad2
+  React-callinvoker: 42c5ba71e3ae4d0f00873f76d7a5949d5a0d67ba
+  React-Codegen: 6d00edad9200475f58a2863f3ee3198839ec3ed1
+  React-Core: 6a46065ac54b1dab4a8783dd53cd5e5c0230b48d
+  React-CoreModules: fd638a7a70bc26a2fe4a85e21427de7a6b0848a7
+  React-cxxreact: b591e270c97201ac2b697a79f1e735327d74161d
+  React-Fabric: 04def1584c2719641bb942b4370613721051dbc9
+  React-graphics: 9313c9c369ee7f4166d29ec16d5c46a27d88acbf
+  React-hermes: e1368b2986124a53d0b2135b6c5364f68c1a877d
+  React-jsi: 2a12903d6f0ddb5da65dc365bc410c7e9f89bb7c
+  React-jsiexecutor: b3de79ba245d72cc09c74c5ec208982a1baca2f1
+  React-jsinspector: c871132ffc238105679470a1f2478e4c994ff089
+  React-logger: 6745cf79901b54feb2ae83e81383140d28e1c0c0
+  React-perflogger: 391177eda42ac6892dfc82c844de2c5c9142301f
+  React-RCTActionSheet: 83ac15ca0a1ab0fc45addd5f3f8256d4ccb1cd5f
+  React-RCTAnimation: b16dc676bdec9df624193e642f5f40767757641e
+  React-RCTAppDelegate: 9bd3811ab5dbb3655348092569d3d2551f76541f
+  React-RCTBlob: 9d2a0bca7ea0646773093e2f8c81234a7faf7490
+  React-RCTFabric: af98628912b9ccffc336c6c147b27ddeed424c5c
+  React-RCTImage: 7e993ad492e07b30267df81c01f84bf37d3ed833
+  React-RCTLinking: 05cf48d94726b9f04a841c2e0d136c82b4f5dafc
+  React-RCTNetwork: a3a3cecd35f4ca6487bc72772b66985e43e7671c
+  React-RCTPushNotification: 21a2a1b8b7787fa6d564a41741307c720ca6275b
+  React-RCTSettings: 992d5a93c0d50e3d5b05bae0f94f39e8e469818a
+  React-RCTTest: cadeb0c95f4bc7337ef0ace92c741731bfecd4e7
+  React-RCTText: 3b4471144bc01fdbd83924bf046028ee2a0a01c0
+  React-RCTVibration: 72619d7a68336e3cbec19253bae778c8b39333ec
+  React-rncore: f4527e81f3f685a830d6ab8892bb516473377273
+  React-runtimeexecutor: 6a6aeba767d850847e968607e78f4330d92ce0fd
+  ReactCommon: ba1811fe72343331261e33b44a0a042430d9d4cc
   ScreenshotManager: e77ad8e427160ebce1f86313e2b21ea56b665285
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: 921eb014669cf9c718ada68b08d362517d564e0c
+  Yoga: 2c72df87fe52c0c7ec0e5cd8e71045aa48bb48dd
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 8da43cb75927abd2bbb2fc21dcebfebb05b89963

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -906,7 +906,7 @@ class TextExample extends React.Component<{...}> {
               &nbsp;
               <Text
                 style={{color: '#fff', fontSize: 13}}
-                textCodeBlock={textCodeBlock}>
+                textCodeBlockStyle={textCodeBlockStyle}>
                 &nbsp;This text.&nbsp;
               </Text>
             </Text>
@@ -915,7 +915,7 @@ class TextExample extends React.Component<{...}> {
               Inline text example&nbsp;
               <Text
                 style={{color: '#fff', fontSize: 13}}
-                textCodeBlock={textCodeBlock}>
+                textCodeBlockStyle={textCodeBlockStyle}>
                 &nbsp;This text.&nbsp;
               </Text>
             </Text>
@@ -924,7 +924,7 @@ class TextExample extends React.Component<{...}> {
               Inline text example&nbsp;
               <Text
                 style={{color: '#fff', fontSize: 13}}
-                textCodeBlock={textCodeBlock}>
+                textCodeBlockStyle={textCodeBlockStyle}>
                 &nbsp;This text should wrapped with a border and displayed
                 inline. This text should wrapped with a border and displayed
                 inline.&nbsp;
@@ -932,7 +932,7 @@ class TextExample extends React.Component<{...}> {
               &nbsp; Inline text example &nbsp;
               <Text
                 style={{color: '#fff', fontSize: 13}}
-                textCodeBlock={textCodeBlock}>
+                textCodeBlockStyle={textCodeBlockStyle}>
                 &nbsp;This text should wrapped with a border and displayed
                 inline. This text should wrapped with a border and displayed
                 inline.&nbsp;
@@ -943,7 +943,7 @@ class TextExample extends React.Component<{...}> {
               Inline text example&nbsp;
               <Text
                 style={{color: '#fff', fontSize: 13}}
-                textCodeBlock={textCodeBlock}>
+                textCodeBlockStyle={textCodeBlockStyle}>
                 &nbsp;T histextshouldwrappedwithaborderanddisplayed inline. This
                 text should wrapped with a border and displayed inline.&nbsp;
               </Text>
@@ -955,7 +955,7 @@ class TextExample extends React.Component<{...}> {
   }
 }
 
-const textCodeBlock = {
+const textCodeBlockStyle = {
   backgroundColor: '#002E22',
   borderColor: '#1B5744',
   borderRadius: 4,

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -929,6 +929,14 @@ class TextExample extends React.Component<{...}> {
                 inline. This text should wrapped with a border and displayed
                 inline.&nbsp;
               </Text>
+              &nbsp; Inline text example &nbsp;
+              <Text
+                style={{color: '#fff', fontSize: 13}}
+                textCodeBlock={textCodeBlock}>
+                &nbsp;This text should wrapped with a border and displayed
+                inline. This text should wrapped with a border and displayed
+                inline.&nbsp;
+              </Text>
             </Text>
 
             <Text style={{lineHeight: 20, fontSize: 15}}>

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -900,10 +900,60 @@ class TextExample extends React.Component<{...}> {
             employee@facebook.com
           </Text>
         </RNTesterBlock>
+        <RNTesterBlock title="Inline code-block">
+          <View>
+            <Text style={{lineHeight: 20, fontSize: 15}}>
+              &nbsp;
+              <Text
+                style={{color: '#fff', fontSize: 13}}
+                textCodeBlock={textCodeBlock}>
+                &nbsp;This text.&nbsp;
+              </Text>
+            </Text>
+
+            <Text style={{lineHeight: 20, fontSize: 15}}>
+              Inline text example&nbsp;
+              <Text
+                style={{color: '#fff', fontSize: 13}}
+                textCodeBlock={textCodeBlock}>
+                &nbsp;This text.&nbsp;
+              </Text>
+            </Text>
+
+            <Text style={{lineHeight: 20, fontSize: 15}}>
+              Inline text example&nbsp;
+              <Text
+                style={{color: '#fff', fontSize: 13}}
+                textCodeBlock={textCodeBlock}>
+                &nbsp;This text should wrapped with a border and displayed
+                inline. This text should wrapped with a border and displayed
+                inline.&nbsp;
+              </Text>
+            </Text>
+
+            <Text style={{lineHeight: 20, fontSize: 15}}>
+              Inline text example&nbsp;
+              <Text
+                style={{color: '#fff', fontSize: 13}}
+                textCodeBlock={textCodeBlock}>
+                &nbsp;T histextshouldwrappedwithaborderanddisplayed inline. This
+                text should wrapped with a border and displayed inline.&nbsp;
+              </Text>
+            </Text>
+          </View>
+        </RNTesterBlock>
       </RNTesterPage>
     );
   }
 }
+
+const textCodeBlock = {
+  backgroundColor: '#002E22',
+  borderColor: '#1B5744',
+  borderRadius: 4,
+  borderWidth: 2,
+};
+
 const styles = StyleSheet.create({
   backgroundColorText: {
     left: 5,

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -1286,7 +1286,7 @@ exports.examples = [
   {
     title: 'Inline code-block',
     render: function (): React.Node {
-      const textCodeBlock = {
+      const textCodeBlockStyle = {
         backgroundColor: '#002E22',
         borderColor: '#1B5744',
         borderRadius: 4,
@@ -1296,26 +1296,34 @@ exports.examples = [
         <View>
           <Text style={{lineHeight: 20}}>
             &nbsp;
-            <Text style={{color: '#fff'}} textCodeBlock={textCodeBlock}>
+            <Text
+              style={{color: '#fff'}}
+              textCodeBlockStyle={textCodeBlockStyle}>
               &nbsp;This text.&nbsp;
             </Text>
           </Text>
 
           <Text style={{lineHeight: 20}}>
             Inline text example&nbsp;
-            <Text style={{color: '#fff'}} textCodeBlock={textCodeBlock}>
+            <Text
+              style={{color: '#fff'}}
+              textCodeBlockStyle={textCodeBlockStyle}>
               &nbsp;This text.&nbsp;
             </Text>
           </Text>
 
           <Text style={{lineHeight: 20}}>
             Inline text example&nbsp;
-            <Text style={{color: '#fff'}} textCodeBlock={textCodeBlock}>
+            <Text
+              style={{color: '#fff'}}
+              textCodeBlockStyle={textCodeBlockStyle}>
               &nbsp;This text should wrapped with a border and displayed inline.
               This text should wrapped with a border and displayed inline.&nbsp;
             </Text>
             &nbsp;Inline text example&nbsp;
-            <Text style={{color: '#fff'}} textCodeBlock={textCodeBlock}>
+            <Text
+              style={{color: '#fff'}}
+              textCodeBlockStyle={textCodeBlockStyle}>
               &nbsp;This text should wrapped with a border and displayed inline.
               This text should wrapped with a border and displayed inline.&nbsp;
             </Text>
@@ -1323,7 +1331,9 @@ exports.examples = [
 
           <Text style={{lineHeight: 20}}>
             Inline text example&nbsp;
-            <Text style={{color: '#fff'}} textCodeBlock={textCodeBlock}>
+            <Text
+              style={{color: '#fff'}}
+              textCodeBlockStyle={textCodeBlockStyle}>
               &nbsp;T histextshouldwrappedwithaborderanddisplayed inline. This
               text should wrapped with a border and displayed inline.&nbsp;
             </Text>

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -1284,6 +1284,50 @@ exports.examples = [
     },
   },
   {
+    title: 'Inline code-block',
+    render: function (): React.Node {
+      const textCodeBlock = {
+        backgroundColor: '#002E22',
+        borderColor: '#1B5744',
+        borderRadius: 4,
+        borderWidth: 2,
+      };
+      return (
+        <View>
+          <Text style={{lineHeight: 20}}>
+            &nbsp;
+            <Text style={{color: '#fff'}} textCodeBlock={textCodeBlock}>
+              &nbsp;This text.&nbsp;
+            </Text>
+          </Text>
+
+          <Text style={{lineHeight: 20}}>
+            Inline text example&nbsp;
+            <Text style={{color: '#fff'}} textCodeBlock={textCodeBlock}>
+              &nbsp;This text.&nbsp;
+            </Text>
+          </Text>
+
+          <Text style={{lineHeight: 20}}>
+            Inline text example&nbsp;
+            <Text style={{color: '#fff'}} textCodeBlock={textCodeBlock}>
+              &nbsp;This text should wrapped with a border and displayed inline.
+              This text should wrapped with a border and displayed inline.&nbsp;
+            </Text>
+          </Text>
+
+          <Text style={{lineHeight: 20}}>
+            Inline text example&nbsp;
+            <Text style={{color: '#fff'}} textCodeBlock={textCodeBlock}>
+              &nbsp;T histextshouldwrappedwithaborderanddisplayed inline. This
+              text should wrapped with a border and displayed inline.&nbsp;
+            </Text>
+          </Text>
+        </View>
+      );
+    },
+  },
+  {
     title: 'Dynamic Type (iOS only)',
     render: function (): React.Node {
       const boldStyle = {fontWeight: 'bold'};

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -1314,6 +1314,11 @@ exports.examples = [
               &nbsp;This text should wrapped with a border and displayed inline.
               This text should wrapped with a border and displayed inline.&nbsp;
             </Text>
+            &nbsp;Inline text example&nbsp;
+            <Text style={{color: '#fff'}} textCodeBlock={textCodeBlock}>
+              &nbsp;This text should wrapped with a border and displayed inline.
+              This text should wrapped with a border and displayed inline.&nbsp;
+            </Text>
           </Text>
 
           <Text style={{lineHeight: 20}}>


### PR DESCRIPTION
<!-- !!!!FILLING OUT THIS TEMPLATE COMPLETELY AND WITH GOOD QUALITY IS MANDATORY!!!! -->

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

# Upstream PR Link
<!-- For the Expensify fork of React-Native, every PR should also be made to the upstream source of React-Native. Provide a link to that PR here. If there is no upstream PR, write a good and detailed explanation of why. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
New `textCodeBlock` prop for a <Text /> component which is used for displaying inline code-blocks. Similar to a `<pre>` tag which supports customizable inline background color and border.

```js
const textCodeBlockStyle = {
  backgroundColor: '#002E22',
  borderColor: '#1B5744',
  borderRadius: 4,
  borderWidth: 2,
};

<Text textCodeBlockStyle={textCodeBlockStyle}>
  &nbsp;This text.&nbsp;
</Text>
```

See [Libraries/Text/TextCodeBlock.js](https://github.com/Expensify/react-native/pull/43/files#diff-6ad9e1a26acf75ca0a50607666f39f6064656f5e4cfec502e0376a833093e431) for the list of available props.

See [packages/rn-tester/js/examples/Text/TextExample.ios.js](https://github.com/Expensify/react-native/pull/43/files#diff-a251d41b798854ebdc060194e6ee3c2be1b8ac811bb6f8d1f2f2666136964334) for a usage example.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[iOS] [Added] - textCodeBlock prop for <Text /> component
[Android] [Added] - textCodeBlock prop for <Text /> component

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Run rn-tester app on both iOS and Android 
- Navigate to Text Component on home screen
- Search for **Inline code-block** section
- Each block wrapped in a `<Text textCodeBlockStyle>` should have be displayed inline, with a background color and a border around it.