### PR TITLE
[Android] Improve consistency for overflowed TextInput

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -1045,7 +1045,16 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     }
 
     @Override
-    public void afterTextChanged(Editable s) {}
+    public void afterTextChanged(Editable s) {
+      if (!mEditText.hasFocus()) {
+        mEditText.post(new Runnable() {
+          @Override
+          public void run() {
+            mEditText.scrollTo(0, 0);
+          }
+        });
+      }
+    }
   }
 
   @Override

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -696,4 +696,15 @@ module.exports = ([
       );
     },
   },
+  {
+    title: 'Overflowed text behavior on render',
+    render: function (): React.Node {
+      return (
+        <TextInput
+          style={styles.default}
+          defaultValue="The quick brown fox expertly jumps over the lazy dog, lying still on the grass."
+        />
+      );
+    },
+  },
 ]: Array<RNTesterModuleExample>);


### PR DESCRIPTION
<!-- !!!!FILLING OUT THIS TEMPLATE COMPLETELY AND WITH GOOD QUALITY IS MANDATORY!!!! -->

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

# Upstream PR Link
<!-- For the Expensify fork of React-Native, every PR should also be made to the upstream source of React-Native. Provide a link to that PR here. If there is no upstream PR, write a good and detailed explanation of why. -->

https://github.com/facebook/react-native/pull/36428

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Coming from this issue: https://github.com/Expensify/App/issues/15310

In the linked issue we have identified a difference in how TextInput components behave when the text is longer than the width of the field on Android compared to other platforms. On other platforms, the beginning of the line of text is shown and the end is clipped. However, on Android, the end of the line of text is displayed during render and auto-fill events.

To make the behavior consistent across all platforms, this pull request updates the Android implementation of TextInput to show the beginning of the line and clip the end, like on other platforms. This is done by adding a scroll function to the afterChangedText event in the existing TextWatcher used for detecting changes in text for the Android widget. This function is triggered when the field is unfocused, and therefore only applies to initial rendering and auto-filling events.


cc @s77rt @johnmlee101

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->


[ANDROID] [Fixed] - TextInput not displaying start of text on render like other platforms

## Test Plan

<details>
<summary>Before Change</summary>

https://user-images.githubusercontent.com/1311325/224193644-363f939e-cf41-467e-abf6-b6e10f2e4696.mp4

</details>

<details>
<summary>After Change</summary>

https://user-images.githubusercontent.com/1311325/224193669-648bae29-47f1-460a-a170-e99247505347.mp4

</details>
