### PR TITLE
Cursor position

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -184,7 +184,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
       initWithStart:[backedTextInputView offsetFromPosition:backedTextInputView.beginningOfDocument
                                                  toPosition:selectedTextRange.start]
                 end:[backedTextInputView offsetFromPosition:backedTextInputView.beginningOfDocument
-                                                 toPosition:selectedTextRange.end]];
+                                                 toPosition:selectedTextRange.end]
+   cursorPosition:[backedTextInputView caretRectForPosition:selectedTextRange.start].origin];
 }
 
 - (void)setSelection:(RCTTextSelection *)selection
@@ -519,6 +520,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
     @"selection" : @{
       @"start" : @(selection.start),
       @"end" : @(selection.end),
+      @"positionY": @(selectionOrigin.y),
+      @"positionX": @(selectionOrigin.x),
     },
   });
 }

--- a/packages/react-native/Libraries/Text/TextInput/RCTTextSelection.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTTextSelection.h
@@ -14,8 +14,9 @@
 
 @property (nonatomic, assign, readonly) NSInteger start;
 @property (nonatomic, assign, readonly) NSInteger end;
+@property (nonatomic, assign, readonly) CGPoint cursorPosition;
 
-- (instancetype)initWithStart:(NSInteger)start end:(NSInteger)end;
+- (instancetype)initWithStart:(NSInteger)start end:(NSInteger)end cursorPosition:(CGPoint)cursorPosition;
 
 @end
 

--- a/packages/react-native/Libraries/Text/TextInput/RCTTextSelection.m
+++ b/packages/react-native/Libraries/Text/TextInput/RCTTextSelection.m
@@ -9,11 +9,12 @@
 
 @implementation RCTTextSelection
 
-- (instancetype)initWithStart:(NSInteger)start end:(NSInteger)end
+- (instancetype)initWithStart:(NSInteger)start end:(NSInteger)end cursorPosition:(CGPoint)cursorPosition
 {
   if (self = [super init]) {
     _start = start;
     _end = end;
+    _cursorPosition = cursorPosition;
   }
   return self;
 }
@@ -27,7 +28,13 @@
   if ([json isKindOfClass:[NSDictionary class]]) {
     NSInteger start = [self NSInteger:json[@"start"]];
     NSInteger end = [self NSInteger:json[@"end"]];
-    return [[RCTTextSelection alloc] initWithStart:start end:end];
+    CGPoint cursorPosition = CGPointMake(
+      [self CGFloat:json[@"cursorPositionX"]],
+      [self CGFloat:json[@"cursorPositionY"]]
+    );
+    return [[RCTTextSelection alloc] initWithStart:start
+                                               end:end 
+                                    cursorPosition:cursorPosition];
   }
 
   return nil;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -1243,15 +1243,17 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     public void onSelectionChanged(int start, int end) {
       // Calculate cursor position
       Layout layout = mReactEditText.getLayout();
-      if (mReactEditText.getLayout() == null) {
-            mReactEditText.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
-                @Override
-                public void onGlobalLayout() {
-                    mReactEditText.getViewTreeObserver().removeOnGlobalLayoutListener(this);
-                    onSelectionChanged(start, end);
-                }
-            });
-            return;
+
+      // Wait for the TextInput to mount, if needed
+      if (layout == null) {
+        mReactEditText.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+          @Override
+          public void onGlobalLayout() {
+            mReactEditText.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+            onSelectionChanged(start, end);
+          }
+        });
+        return;
         }
 
       int line = layout.getLineForOffset(start);
@@ -1273,8 +1275,8 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
             new ReactTextInputSelectionEvent(
                 mSurfaceId,
                 mReactEditText.getId(),
-                realStart, 
-                realEnd, 
+                realStart,
+                realEnd,
                 Math.round(PixelUtil.toDIPFromPixel(cursorPositionX)),
                 Math.round(PixelUtil.toDIPFromPixel(cursorPositionY))));
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -81,6 +81,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Locale;
 import java.util.Map;
+import android.view.ViewTreeObserver;
 
 /** Manages instances of TextInput. */
 @ReactModule(name = ReactTextInputManager.REACT_CLASS)
@@ -1240,6 +1241,24 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
     @Override
     public void onSelectionChanged(int start, int end) {
+      // Calculate cursor position
+      Layout layout = mReactEditText.getLayout();
+      if (mReactEditText.getLayout() == null) {
+            mReactEditText.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+                @Override
+                public void onGlobalLayout() {
+                    mReactEditText.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                    onSelectionChanged(start, end);
+                }
+            });
+            return;
+        }
+
+      int line = layout.getLineForOffset(start);
+      int baseline = layout.getLineBaseline(line);
+      int ascent = layout.getLineAscent(line);
+      float cursorPositionX = layout.getPrimaryHorizontal(start);
+      float cursorPositionY = baseline + ascent;
       // Android will call us back for both the SELECTION_START span and SELECTION_END span in text
       // To prevent double calling back into js we cache the result of the previous call and only
       // forward it on if we have new values
@@ -1252,7 +1271,12 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       if (mPreviousSelectionStart != realStart || mPreviousSelectionEnd != realEnd) {
         mEventDispatcher.dispatchEvent(
             new ReactTextInputSelectionEvent(
-                mSurfaceId, mReactEditText.getId(), realStart, realEnd));
+                mSurfaceId,
+                mReactEditText.getId(),
+                realStart, 
+                realEnd, 
+                Math.round(PixelUtil.toDIPFromPixel(cursorPositionX)),
+                Math.round(PixelUtil.toDIPFromPixel(cursorPositionY))));
 
         mPreviousSelectionStart = realStart;
         mPreviousSelectionEnd = realEnd;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSelectionEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSelectionEvent.java
@@ -19,17 +19,31 @@ import com.facebook.react.uimanager.events.Event;
 
   private int mSelectionStart;
   private int mSelectionEnd;
+  private float mCursorPositionX;
+  private float mCursorPositionY;
 
   @Deprecated
-  public ReactTextInputSelectionEvent(int viewId, int selectionStart, int selectionEnd) {
-    this(-1, viewId, selectionStart, selectionEnd);
+  public ReactTextInputSelectionEvent(
+      int viewId,
+      int selectionStart,
+      int selectionEnd,
+      float cursorPositionX,
+      float cursorPositionY) {
+    this(-1, viewId, selectionStart, selectionEnd, cursorPositionX, cursorPositionY);
   }
 
   public ReactTextInputSelectionEvent(
-      int surfaceId, int viewId, int selectionStart, int selectionEnd) {
+      int surfaceId,
+      int viewId,
+      int selectionStart,
+      int selectionEnd,
+      float cursorPositionX,
+      float cursorPositionY) {
     super(surfaceId, viewId);
     mSelectionStart = selectionStart;
     mSelectionEnd = selectionEnd;
+    mCursorPositionX = cursorPositionX;
+    mCursorPositionY = cursorPositionY;
   }
 
   @Override
@@ -45,6 +59,8 @@ import com.facebook.react.uimanager.events.Event;
     WritableMap selectionData = Arguments.createMap();
     selectionData.putInt("end", mSelectionEnd);
     selectionData.putInt("start", mSelectionStart);
+    selectionData.putDouble("cursorPositionX", mCursorPositionX);
+    selectionData.putDouble("cursorPositionY", mCursorPositionY);
 
     eventData.putMap("selection", selectionData);
     return eventData;


### PR DESCRIPTION
<!-- !!!!FILLING OUT THIS TEMPLATE COMPLETELY AND WITH GOOD QUALITY IS MANDATORY!!!! -->

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

# Upstream PR Link
<!-- For the Expensify fork of React-Native, every PR should also be made to the upstream source of React-Native. Provide a link to that PR here. If there is no upstream PR, write a good and detailed explanation of why. -->
https://github.com/facebook/react-native/pull/36979
https://github.com/Expensify/App/issues/16078
## Summary
This PR extends the onSelectionChange method on textInput to return the x and y position of the input caret
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
In addition to the start and end indices of the selected text onSelectionChange returns also positionY and positionX  position of the input caret. The new object returned by the method looks like this:

```{
  selection: {
    start: number,
    end: number,
    positionY: number,
    positionX: number
  }
}
```

https://user-images.githubusercontent.com/48593211/233383277-2214564f-81b7-4552-9ed2-f1ad8d8b4d0b.mp4

positionX and positionY represent the coordinates inside the text input area, not including padding or margin. If you add a margin, you should add that extra space when using these coords to draw stuff on the text input.
<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[CATEGORY] [TYPE] - Message

## Test Plan

 added console.log statements to the onSelectionChange method to print the positionY and positionX values of the input caret. This allows for easy verification of the correct functioning of the new functionality added by this PR.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
