### PR TITLE
[Android] fix scrollTo() not working when there is an animation

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -1052,6 +1052,10 @@ public class ReactScrollView extends ScrollView
    */
   @Override
   public void scrollTo(int x, int y) {
+	// hack used to stop the animation if there is one
+	// otherwise the animation keeps going after scrollTo which makes scrollTo useless
+	smoothScrollBy(0,0);
+	
     super.scrollTo(x, y);
     ReactScrollViewHelper.updateFabricScrollState(this);
     setPendingContentOffsets(x, y);


### PR DESCRIPTION
# Upstream PR Link

## Summary

This PR resolves this issue [Expensify/App Issue #15964](https://github.com/Expensify/App/issues/15964)

The problem happens when we call scrollTo during an animation, for example when the user is scrolling. Since the animation is never stopped, the scrollTo becomes useless because on the next frame the animation will make the screen go back to it's original position.

To stop the animation we call smoothScrollBy(0,0), this is a hack but this is the recommended way to stop the animation since the method endFling() has been restricted.
See https://developer.android.com/about/versions/10/non-sdk-q

## Changelog

[Android] [Fixed] - Fix scrollTo() not working during animations

## Test Plan

