### PR TITLE
Define selectionOrigin

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -515,6 +515,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   }
 
   RCTTextSelection *selection = self.selection;
+  UITextRange *selectedTextRange = self.backedTextInputView.selectedTextRange;
+  CGPoint selectionOrigin = [self.backedTextInputView caretRectForPosition:selectedTextRange.start].origin;
 
   _onSelectionChange(@{
     @"selection" : @{

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -522,8 +522,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
     @"selection" : @{
       @"start" : @(selection.start),
       @"end" : @(selection.end),
-      @"positionY": @(selectionOrigin.y),
-      @"positionX": @(selectionOrigin.x),
+      @"cursorPositionY": @(selectionOrigin.y),
+      @"cursorPositionX": @(selectionOrigin.x),
     },
   });
 }


### PR DESCRIPTION
<!-- !!!!FILLING OUT THIS TEMPLATE COMPLETELY AND WITH GOOD QUALITY IS MANDATORY!!!! -->

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

# Upstream PR Link
<!-- For the Expensify fork of React-Native, every PR should also be made to the upstream source of React-Native. Provide a link to that PR here. If there is no upstream PR, write a good and detailed explanation of why. -->

## Summary
It's a fix for https://github.com/Expensify/react-native/pull/49. There Missing of defining of selectionOrigin in `textInputDidChangeSelection`
It was discovered in updating RN process https://github.com/Expensify/App/pull/18507#issuecomment-1539848936
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[CATEGORY] [TYPE] - Message

## Test Plan
 For details on the test plan, please refer to https://github.com/Expensify/react-native/pull/49
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
