### PR TITLE
Substr measurements expensify

### DIFF
--- a/packages/react-native/Libraries/Text/Text/RCTTextShadowView.h
+++ b/packages/react-native/Libraries/Text/Text/RCTTextShadowView.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL adjustsFontSizeToFit;
 @property (nonatomic, assign) CGFloat minimumFontScale;
 @property (nonatomic, copy) RCTDirectEventBlock onTextLayout;
+@property (nonatomic, copy) NSArray *textLayoutConfig;
 
 - (void)uiManagerWillPerformMounting;
 

--- a/packages/react-native/Libraries/Text/Text/RCTTextShadowView.h
+++ b/packages/react-native/Libraries/Text/Text/RCTTextShadowView.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL adjustsFontSizeToFit;
 @property (nonatomic, assign) CGFloat minimumFontScale;
 @property (nonatomic, copy) RCTDirectEventBlock onTextLayout;
-@property (nonatomic, copy) NSArray *textLayoutConfig;
+@property (nonatomic, copy) NSArray *textLayoutRegions;
 
 - (void)uiManagerWillPerformMounting;
 

--- a/packages/react-native/Libraries/Text/Text/RCTTextViewManager.m
+++ b/packages/react-native/Libraries/Text/Text/RCTTextViewManager.m
@@ -32,6 +32,7 @@ RCT_REMAP_SHADOW_PROPERTY(adjustsFontSizeToFit, adjustsFontSizeToFit, BOOL)
 RCT_REMAP_SHADOW_PROPERTY(minimumFontScale, minimumFontScale, CGFloat)
 
 RCT_EXPORT_SHADOW_PROPERTY(onTextLayout, RCTDirectEventBlock)
+RCT_EXPORT_SHADOW_PROPERTY(textLayoutConfig, NSArray)
 
 RCT_EXPORT_VIEW_PROPERTY(selectable, BOOL)
 

--- a/packages/react-native/Libraries/Text/Text/RCTTextViewManager.m
+++ b/packages/react-native/Libraries/Text/Text/RCTTextViewManager.m
@@ -32,7 +32,7 @@ RCT_REMAP_SHADOW_PROPERTY(adjustsFontSizeToFit, adjustsFontSizeToFit, BOOL)
 RCT_REMAP_SHADOW_PROPERTY(minimumFontScale, minimumFontScale, CGFloat)
 
 RCT_EXPORT_SHADOW_PROPERTY(onTextLayout, RCTDirectEventBlock)
-RCT_EXPORT_SHADOW_PROPERTY(textLayoutConfig, NSArray)
+RCT_EXPORT_SHADOW_PROPERTY(textLayoutRegions, NSArray)
 
 RCT_EXPORT_VIEW_PROPERTY(selectable, BOOL)
 

--- a/packages/react-native/Libraries/Text/TextNativeComponent.js
+++ b/packages/react-native/Libraries/Text/TextNativeComponent.js
@@ -44,7 +44,7 @@ const textViewConfig = {
     minimumFontScale: true,
     textBreakStrategy: true,
     onTextLayout: true,
-    textLayoutConfig: true,
+    textLayoutRegions: true,
     onInlineViewLayout: true,
     dataDetectorType: true,
     android_hyphenationFrequency: true,

--- a/packages/react-native/Libraries/Text/TextNativeComponent.js
+++ b/packages/react-native/Libraries/Text/TextNativeComponent.js
@@ -44,6 +44,7 @@ const textViewConfig = {
     minimumFontScale: true,
     textBreakStrategy: true,
     onTextLayout: true,
+    textLayoutConfig: true,
     onInlineViewLayout: true,
     dataDetectorType: true,
     android_hyphenationFrequency: true,

--- a/packages/react-native/Libraries/Text/TextProps.js
+++ b/packages/react-native/Libraries/Text/TextProps.js
@@ -169,6 +169,11 @@ export type TextProps = $ReadOnly<{|
   onTextLayout?: ?(event: TextLayoutEvent) => mixed,
 
   /**
+   * Regions for text layout tracking
+   */
+  textLayoutConfig?: ?$ReadOnlyArray<number>,
+
+  /**
    * Defines how far your touch may move off of the button, before
    * deactivating the button.
    *

--- a/packages/react-native/Libraries/Text/TextProps.js
+++ b/packages/react-native/Libraries/Text/TextProps.js
@@ -171,7 +171,7 @@ export type TextProps = $ReadOnly<{|
   /**
    * Regions for text layout tracking
    */
-  textLayoutConfig?: ?$ReadOnlyArray<number>,
+  textLayoutRegions?: ?$ReadOnlyArray<number>,
 
   /**
    * Defines how far your touch may move off of the button, before

--- a/packages/react-native/Libraries/Text/TextProps.js
+++ b/packages/react-native/Libraries/Text/TextProps.js
@@ -171,7 +171,7 @@ export type TextProps = $ReadOnly<{|
   /**
    * Regions for text layout tracking
    */
-  textLayoutRegions?: ?$ReadOnlyArray<number>,
+  textLayoutRegions?: ?$ReadOnlyArray<$ReadOnlyArray<number>>,
 
   /**
    * Defines how far your touch may move off of the button, before

--- a/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
@@ -33,11 +33,22 @@ interface TextLayoutLine {
   y: number;
 }
 
+interface TextLayoutRegion {
+  text: string;
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+  line: number;
+  region: number;
+}
+
 /**
  * @see TextProps.onTextLayout
  */
 export interface TextLayoutEventData extends TargetedEvent {
   lines: TextLayoutLine[];
+  regions: TextLayoutRegion[];
 }
 
 // Similar to React.SyntheticEvent except for nativeEvent

--- a/packages/react-native/Libraries/Types/CoreEventTypes.js
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.js
@@ -72,6 +72,16 @@ export type TextLayout = $ReadOnly<{|
   xHeight: number,
 |}>;
 
+export type TextRegion = $ReadOnly<{|
+  text: string,
+  height: number,
+  width: number,
+  x: number,
+  y: number,
+  line: number,
+  region: number,
+|}>;
+
 export type LayoutEvent = SyntheticEvent<
   $ReadOnly<{|
     layout: Layout,
@@ -81,6 +91,7 @@ export type LayoutEvent = SyntheticEvent<
 export type TextLayoutEvent = SyntheticEvent<
   $ReadOnly<{|
     lines: Array<TextLayout>,
+    regions: Array<TextRegion>,
   |}>,
 >;
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -443,9 +443,9 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
   }
 
   @SuppressWarnings("unused")
-  private NativeArray measureLines(
+  private NativeMap measureLines(
       ReadableMap attributedString, ReadableMap paragraphAttributes, float width, float height) {
-    return (NativeArray)
+    return (NativeMap)
         TextLayoutManager.measureLines(
             mReactApplicationContext,
             attributedString,
@@ -454,12 +454,12 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
   }
 
   @SuppressWarnings("unused")
-  private NativeArray measureLinesMapBuffer(
+  private NativeMap measureLinesMapBuffer(
       ReadableMapBuffer attributedString,
       ReadableMapBuffer paragraphAttributes,
       float width,
       float height) {
-    return (NativeArray)
+    return (NativeMap)
         TextLayoutManagerMapBuffer.measureLines(
             mReactApplicationContext,
             attributedString,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -51,6 +51,7 @@ import com.facebook.react.bridge.UIManagerListener;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.build.ReactBuildConfig;
+import com.facebook.react.common.mapbuffer.MapBuffer;
 import com.facebook.react.common.mapbuffer.ReadableMapBuffer;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.fabric.events.EventBeatManager;
@@ -444,13 +445,18 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
 
   @SuppressWarnings("unused")
   private NativeMap measureLines(
-      ReadableMap attributedString, ReadableMap paragraphAttributes, float width, float height, ReadableArray textLayoutRegions) {
+      ReadableMap attributedString,
+      ReadableMap paragraphAttributes,
+      float width,
+      float height,
+      MapBuffer textLayoutRegions) {
     return (NativeMap)
         TextLayoutManager.measureLines(
             mReactApplicationContext,
             attributedString,
             paragraphAttributes,
-            PixelUtil.toPixelFromDIP(width));
+            PixelUtil.toPixelFromDIP(width),
+            textLayoutRegions);
   }
 
   @SuppressWarnings("unused")
@@ -458,13 +464,15 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
       ReadableMapBuffer attributedString,
       ReadableMapBuffer paragraphAttributes,
       float width,
-      float height) {
+      float height,
+      ReadableMapBuffer textLayoutRegions) {
     return (NativeMap)
         TextLayoutManagerMapBuffer.measureLines(
             mReactApplicationContext,
             attributedString,
             paragraphAttributes,
-            PixelUtil.toPixelFromDIP(width));
+            PixelUtil.toPixelFromDIP(width),
+            textLayoutRegions);
   }
 
   @SuppressWarnings("unused")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -444,7 +444,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
 
   @SuppressWarnings("unused")
   private NativeMap measureLines(
-      ReadableMap attributedString, ReadableMap paragraphAttributes, float width, float height) {
+      ReadableMap attributedString, ReadableMap paragraphAttributes, float width, float height, ReadableArray textLayoutRegions) {
     return (NativeMap)
         TextLayoutManager.measureLines(
             mReactApplicationContext,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.java
@@ -59,8 +59,8 @@ public class FontMetricsUtil {
       line.putString(
           "text", text.subSequence(layout.getLineStart(i), layout.getLineEnd(i)).toString());
 
-      int start = 10;
-      int end = 40;
+      int start = 0;
+      int end = 5;
       int lineStartIndex = layout.getLineStart(i);
       int lineEndIndex = layout.getLineEnd(i);
       int startIndex = Math.max(lineStartIndex, start);
@@ -73,8 +73,12 @@ public class FontMetricsUtil {
       Rect charBounds = new Rect(xStart, yStart, xEnd, yEnd);
 
       WritableMap region = Arguments.createMap();
-      region.putDouble("width", charBounds.width());
-      region.putDouble("height", charBounds.height());
+      region.putDouble("x", charBounds.width() / dm.density);
+      region.putDouble("y", charBounds.height() / dm.density);
+      region.putDouble("width", 1.2);
+      region.putDouble("height", 1.2);
+      region.putString(
+          "text", text.subSequence(layout.getLineStart(i), layout.getLineEnd(i)).toString());
 
       lines.pushMap(line);
       regions.pushMap(region);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.java
@@ -61,22 +61,28 @@ public class FontMetricsUtil {
       line.putString(
           "text", text.subSequence(layout.getLineStart(i), layout.getLineEnd(i)).toString());
 
-      for (int j = 0; j < textLayoutRegions.getCount(); j++) {
+      lines.pushMap(line);
+    }
+
+    for (int j = 0; j < textLayoutRegions.getCount(); j++) {
+      for (int i = 0; i < layout.getLineCount(); i++) {
+        Rect bounds = new Rect();
+        layout.getLineBounds(i, bounds);
+
         MapBuffer textLayoutRegion = textLayoutRegions.getMapBuffer(j);
 
+        int offset = layout.getLineEnd(i) >= textLayoutRegion.getInt(1) ? 0 : 1; 
         int startIndex = Math.max(layout.getLineStart(i), textLayoutRegion.getInt(0));
-        int endIndex = Math.min(layout.getLineEnd(i), textLayoutRegion.getInt(1));
+        int endIndex = Math.min(layout.getLineEnd(i), textLayoutRegion.getInt(1)) - offset;
 
-        if (startIndex > endIndex) {
+        if (startIndex > endIndex + 1) {
           break;
         }
-
-        int offset = layout.getLineEnd(i) >= textLayoutRegion.getInt(1) ? 0 : 1; 
 
         Rect regionBounds = new Rect(
           (int)layout.getPrimaryHorizontal(startIndex),
           bounds.top,
-          (int)layout.getPrimaryHorizontal(endIndex - offset),
+          (int)layout.getPrimaryHorizontal(endIndex),
           bounds.bottom);
 
         WritableMap region = Arguments.createMap();
@@ -89,8 +95,6 @@ public class FontMetricsUtil {
         region.putInt("line", i);
         regions.pushMap(region);
       }
-
-      lines.pushMap(line);
     }
 
     WritableMap textLayoutMetrics = Arguments.createMap();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.java
@@ -71,10 +71,12 @@ public class FontMetricsUtil {
           break;
         }
 
+        int offset = layout.getLineEnd(i) >= textLayoutRegion.getInt(1) ? 0 : 1; 
+
         Rect regionBounds = new Rect(
           (int)layout.getPrimaryHorizontal(startIndex),
           bounds.top,
-          (int)layout.getPrimaryHorizontal(endIndex - 1),
+          (int)layout.getPrimaryHorizontal(endIndex - offset),
           bounds.bottom);
 
         WritableMap region = Arguments.createMap();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -109,14 +109,14 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
 
           if (mShouldNotifyOnTextLayout) {
             ThemedReactContext themedReactContext = getThemedContext();
-            WritableMap textLayoutMetrics =
-                FontMetricsUtil.getFontMetrics(
-                    text, layout, sTextPaintInstance, themedReactContext);
+//             WritableMap textLayoutMetrics =
+//                 FontMetricsUtil.getFontMetrics(
+//                     text, layout, sTextPaintInstance, themedReactContext, mTextLayoutRegions);
 
             if (themedReactContext.hasActiveReactInstance()) {
-              themedReactContext
-                  .getJSModule(RCTEventEmitter.class)
-                  .receiveEvent(getReactTag(), "topTextLayout", textLayoutMetrics);
+//              themedReactContext
+//                  .getJSModule(RCTEventEmitter.class)
+//                  .receiveEvent(getReactTag(), "topTextLayout", textLayoutMetrics);
             } else {
               ReactSoftExceptionLogger.logSoftException(
                   "ReactTextShadowNode",

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -41,7 +41,6 @@ import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureOutput;
 import com.facebook.yoga.YogaNode;
 import java.util.ArrayList;
-import com.facebook.common.logging.FLog;
 
 /**
  * {@link ReactBaseTextShadowNode} concrete class for anchor {@code Text} node.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -24,6 +24,7 @@ import com.facebook.react.bridge.ReactNoCrashSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.uimanager.NativeViewHierarchyOptimizer;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactShadowNode;
@@ -40,6 +41,7 @@ import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureOutput;
 import com.facebook.yoga.YogaNode;
 import java.util.ArrayList;
+import com.facebook.common.logging.FLog;
 
 /**
  * {@link ReactBaseTextShadowNode} concrete class for anchor {@code Text} node.
@@ -58,6 +60,7 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
   private @Nullable Spannable mPreparedSpannableText;
 
   private boolean mShouldNotifyOnTextLayout;
+  private ReadableArray mTextLayoutConfig;
 
   private final YogaMeasureFunction mTextMeasureFunction =
       new YogaMeasureFunction() {
@@ -355,6 +358,11 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
   @ReactProp(name = "onTextLayout")
   public void setShouldNotifyOnTextLayout(boolean shouldNotifyOnTextLayout) {
     mShouldNotifyOnTextLayout = shouldNotifyOnTextLayout;
+  }
+
+  @ReactProp(name = "textLayoutConfig")
+  public void setTextLayoutConfig(ReadableArray textLayoutConfig) {
+    mTextLayoutConfig = textLayoutConfig;
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -25,6 +25,7 @@ import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.common.mapbuffer.MapBuffer;
 import com.facebook.react.uimanager.NativeViewHierarchyOptimizer;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactShadowNode;
@@ -59,7 +60,7 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
   private @Nullable Spannable mPreparedSpannableText;
 
   private boolean mShouldNotifyOnTextLayout;
-  private ReadableArray mTextLayoutRegions;
+  private MapBuffer mTextLayoutRegions;
 
   private final YogaMeasureFunction mTextMeasureFunction =
       new YogaMeasureFunction() {
@@ -109,14 +110,14 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
 
           if (mShouldNotifyOnTextLayout) {
             ThemedReactContext themedReactContext = getThemedContext();
-//             WritableMap textLayoutMetrics =
-//                 FontMetricsUtil.getFontMetrics(
-//                     text, layout, sTextPaintInstance, themedReactContext, mTextLayoutRegions);
+             WritableMap textLayoutMetrics =
+                 FontMetricsUtil.getFontMetrics(
+                     text, layout, sTextPaintInstance, themedReactContext, mTextLayoutRegions);
 
             if (themedReactContext.hasActiveReactInstance()) {
-//              themedReactContext
-//                  .getJSModule(RCTEventEmitter.class)
-//                  .receiveEvent(getReactTag(), "topTextLayout", textLayoutMetrics);
+              themedReactContext
+                  .getJSModule(RCTEventEmitter.class)
+                  .receiveEvent(getReactTag(), "topTextLayout", textLayoutMetrics);
             } else {
               ReactSoftExceptionLogger.logSoftException(
                   "ReactTextShadowNode",
@@ -360,7 +361,7 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
 
   @ReactProp(name = "textLayoutRegions")
   public void setTextLayoutRegions(ReadableArray textLayoutRegions) {
-    mTextLayoutRegions = textLayoutRegions;
+    mTextLayoutRegions = (MapBuffer) textLayoutRegions;
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -109,15 +109,14 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
 
           if (mShouldNotifyOnTextLayout) {
             ThemedReactContext themedReactContext = getThemedContext();
-            WritableArray lines =
+            WritableMap textLayoutMetrics =
                 FontMetricsUtil.getFontMetrics(
                     text, layout, sTextPaintInstance, themedReactContext);
-            WritableMap event = Arguments.createMap();
-            event.putArray("lines", lines);
+
             if (themedReactContext.hasActiveReactInstance()) {
               themedReactContext
                   .getJSModule(RCTEventEmitter.class)
-                  .receiveEvent(getReactTag(), "topTextLayout", event);
+                  .receiveEvent(getReactTag(), "topTextLayout", textLayoutMetrics);
             } else {
               ReactSoftExceptionLogger.logSoftException(
                   "ReactTextShadowNode",

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -60,7 +60,7 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
   private @Nullable Spannable mPreparedSpannableText;
 
   private boolean mShouldNotifyOnTextLayout;
-  private ReadableArray mTextLayoutConfig;
+  private ReadableArray mTextLayoutRegions;
 
   private final YogaMeasureFunction mTextMeasureFunction =
       new YogaMeasureFunction() {
@@ -360,9 +360,9 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
     mShouldNotifyOnTextLayout = shouldNotifyOnTextLayout;
   }
 
-  @ReactProp(name = "textLayoutConfig")
-  public void setTextLayoutConfig(ReadableArray textLayoutConfig) {
-    mTextLayoutConfig = textLayoutConfig;
+  @ReactProp(name = "textLayoutRegions")
+  public void setTextLayoutRegions(ReadableArray textLayoutRegions) {
+    mTextLayoutRegions = textLayoutRegions;
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -30,7 +30,7 @@ import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableNativeMap;
-import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactStylesDiffMap;
@@ -564,7 +564,7 @@ public class TextLayoutManager {
     return YogaMeasureOutput.make(widthInSP, heightInSP);
   }
 
-  public static WritableArray measureLines(
+  public static WritableMap measureLines(
       @NonNull Context context,
       ReadableMap attributedString,
       ReadableMap paragraphAttributes,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -32,6 +32,8 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableNativeMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.build.ReactBuildConfig;
+import com.facebook.react.common.mapbuffer.MapBuffer;
+import com.facebook.react.common.mapbuffer.ReadableMapBuffer;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactStylesDiffMap;
 import com.facebook.react.uimanager.ViewProps;
@@ -568,7 +570,8 @@ public class TextLayoutManager {
       @NonNull Context context,
       ReadableMap attributedString,
       ReadableMap paragraphAttributes,
-      float width) {
+      float width,
+      MapBuffer textLayoutRegions) {
     Spannable text = getOrCreateSpannableForText(context, attributedString, null);
     BoringLayout.Metrics boring = BoringLayout.isBoring(text, sTextPaintInstance);
 
@@ -592,7 +595,7 @@ public class TextLayoutManager {
             includeFontPadding,
             textBreakStrategy,
             hyphenationFrequency);
-    return FontMetricsUtil.getFontMetrics(text, layout, sTextPaintInstance, context);
+    return FontMetricsUtil.getFontMetrics(text, layout, sTextPaintInstance, context, textLayoutRegions);
   }
 
   // TODO T31905686: This class should be private

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -27,6 +27,7 @@ import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.ReactNoCrashSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.common.mapbuffer.MapBuffer;
@@ -585,7 +586,8 @@ public class TextLayoutManagerMapBuffer {
       @NonNull Context context,
       MapBuffer attributedString,
       MapBuffer paragraphAttributes,
-      float width) {
+      float width,
+      MapBuffer textLayoutRegions) {
 
     Spannable text = getOrCreateSpannableForText(context, attributedString, null);
     BoringLayout.Metrics boring = BoringLayout.isBoring(text, sTextPaintInstance);
@@ -611,7 +613,7 @@ public class TextLayoutManagerMapBuffer {
             textBreakStrategy,
             hyphenationFrequency);
 
-    return FontMetricsUtil.getFontMetrics(text, layout, sTextPaintInstance, context);
+    return FontMetricsUtil.getFontMetrics(text, layout, sTextPaintInstance, context, textLayoutRegions);
   }
 
   // TODO T31905686: This class should be private

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManagerMapBuffer.java
@@ -27,7 +27,7 @@ import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.ReactNoCrashSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
-import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.common.mapbuffer.MapBuffer;
 import com.facebook.react.uimanager.PixelUtil;
@@ -581,7 +581,7 @@ public class TextLayoutManagerMapBuffer {
     return YogaMeasureOutput.make(widthInSP, heightInSP);
   }
 
-  public static WritableArray measureLines(
+  public static WritableMap measureLines(
       @NonNull Context context,
       MapBuffer attributedString,
       MapBuffer paragraphAttributes,
@@ -610,6 +610,7 @@ public class TextLayoutManagerMapBuffer {
             includeFontPadding,
             textBreakStrategy,
             hyphenationFrequency);
+
     return FontMetricsUtil.getFontMetrics(text, layout, sTextPaintInstance, context);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -21,7 +21,9 @@
 #include <react/renderer/core/conversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
+#include <react/renderer/textlayoutmanager/TextMeasureCache.h>
 #include <cmath>
+#include <vector>
 
 #ifdef ANDROID
 #include <react/renderer/mapbuffer/MapBuffer.h>
@@ -826,6 +828,31 @@ inline void fromRawValue(
   LOG(ERROR) << "Unsupported HyphenationFrequency type";
   react_native_expect(false);
   result = HyphenationFrequency::None;
+}
+
+inline std::string toString(const TextLayoutRegions &textLayoutRegions) {
+  LOG(ERROR) << "Unsupported HyphenationFrequency value";
+  react_native_expect(false);
+  return "none";
+}
+
+inline void fromRawValue(
+    const PropsParserContext &context,
+    const RawValue &value,
+    TextLayoutRegions &result) {
+  react_native_expect(value.hasType<std::vector<std::vector<int>>>());
+  if (value.hasType<std::vector<std::vector<int>>>()) {
+    auto regions = std::vector<std::vector<int>>{value};
+    for (const auto &region : regions) {
+      std::vector<int> chunks;
+      for (const auto &chunk : region) {
+        chunks.push_back(chunk);
+      }
+      result.push_back(chunks);
+    }
+  } else {
+    LOG(ERROR) << "Unsupported FontVariant type";
+  }
 }
 
 inline ParagraphAttributes convertRawProp(

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -844,14 +844,19 @@ inline void fromRawValue(
   if (value.hasType<std::vector<std::vector<int>>>()) {
     auto regions = std::vector<std::vector<int>>{value};
     for (const auto &region : regions) {
-      std::vector<int> chunks;
-      for (const auto &chunk : region) {
-        chunks.push_back(chunk);
+      if (region.size() == 2) {
+        std::vector<int> chunks;
+        for (const auto &chunk : region) {
+          chunks.push_back(chunk);
+        }
+        result.push_back(chunks);
+      } else {
+        LOG(ERROR) << "Unsupported TextLayoutRegion value";
+        react_native_expect(false);
       }
-      result.push_back(chunks);
     }
   } else {
-    LOG(ERROR) << "Unsupported FontVariant type";
+    LOG(ERROR) << "Unsupported TextLayoutRegions type";
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -830,12 +830,6 @@ inline void fromRawValue(
   result = HyphenationFrequency::None;
 }
 
-inline std::string toString(const TextLayoutRegions &textLayoutRegions) {
-  LOG(ERROR) << "Unsupported HyphenationFrequency value";
-  react_native_expect(false);
-  return "none";
-}
-
 inline void fromRawValue(
     const PropsParserContext &context,
     const RawValue &value,
@@ -858,13 +852,6 @@ inline void fromRawValue(
   } else {
     LOG(ERROR) << "Unsupported TextLayoutRegions type";
   }
-}
-
-inline folly::dynamic toDynamic(
-    const TextLayoutRegions &textLayoutRegions) {
-  auto values = folly::dynamic::object();
-  
-  return values;
 }
 
 inline ParagraphAttributes convertRawProp(

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -860,6 +860,19 @@ inline void fromRawValue(
   }
 }
 
+inline MapBuffer toMapBuffer(const TextLayoutRegions &textLayoutRegions) {
+  auto builder = MapBufferBuilder();
+
+  return builder.build();
+}
+
+inline folly::dynamic toDynamic(
+    const TextLayoutRegions &textLayoutRegions) {
+  auto values = folly::dynamic::object();
+  
+  return values;
+}
+
 inline ParagraphAttributes convertRawProp(
     const PropsParserContext &context,
     RawProps const &rawProps,

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -861,9 +861,21 @@ inline void fromRawValue(
 }
 
 inline MapBuffer toMapBuffer(const TextLayoutRegions &textLayoutRegions) {
-  auto builder = MapBufferBuilder();
+  auto regionsBuilder = MapBufferBuilder();
+  unsigned regionIdx = 0;
 
-  return builder.build();
+  for (const auto &region : textLayoutRegions) {
+      unsigned chunkIdx = 0;
+      auto chunksBuilder = MapBufferBuilder();
+      for (const auto &chunk : region) {
+          chunksBuilder.putInt(chunkIdx, chunk);
+          ++chunkIdx;
+      }
+      regionsBuilder.putMapBuffer(regionIdx, chunksBuilder.build());
+      ++regionIdx;
+  }
+
+  return regionsBuilder.build();
 }
 
 inline folly::dynamic toDynamic(

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -860,24 +860,6 @@ inline void fromRawValue(
   }
 }
 
-inline MapBuffer toMapBuffer(const TextLayoutRegions &textLayoutRegions) {
-  auto regionsBuilder = MapBufferBuilder();
-  unsigned regionIdx = 0;
-
-  for (const auto &region : textLayoutRegions) {
-      unsigned chunkIdx = 0;
-      auto chunksBuilder = MapBufferBuilder();
-      for (const auto &chunk : region) {
-          chunksBuilder.putInt(chunkIdx, chunk);
-          ++chunkIdx;
-      }
-      regionsBuilder.putMapBuffer(regionIdx, chunksBuilder.build());
-      ++regionIdx;
-  }
-
-  return regionsBuilder.build();
-}
-
 inline folly::dynamic toDynamic(
     const TextLayoutRegions &textLayoutRegions) {
   auto values = folly::dynamic::object();
@@ -1361,6 +1343,24 @@ inline MapBuffer toMapBuffer(const AttributedString &attributedString) {
   auto fragmentsMap = fragmentsBuilder.build();
   builder.putMapBuffer(AS_KEY_FRAGMENTS, fragmentsMap);
   return builder.build();
+}
+
+inline MapBuffer toMapBuffer(const TextLayoutRegions &textLayoutRegions) {
+  auto regionsBuilder = MapBufferBuilder();
+  unsigned regionIdx = 0;
+
+  for (const auto &region : textLayoutRegions) {
+      unsigned chunkIdx = 0;
+      auto chunksBuilder = MapBufferBuilder();
+      for (const auto &chunk : region) {
+          chunksBuilder.putInt(chunkIdx, chunk);
+          ++chunkIdx;
+      }
+      regionsBuilder.putMapBuffer(regionIdx, chunksBuilder.build());
+      ++regionIdx;
+  }
+
+  return regionsBuilder.build();
 }
 
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.cpp
@@ -35,10 +35,13 @@ static jsi::Value linesMeasurementsPayload(
   for (size_t i = 0; i < regionsMeasurements.size(); ++i) {
     auto const &regionMeasurement = regionsMeasurements[i];
     auto jsiRegion = jsi::Object(runtime);
+    jsiRegion.setProperty(runtime, "text", regionMeasurement.text);
     jsiRegion.setProperty(runtime, "x", regionMeasurement.frame.origin.x);
     jsiRegion.setProperty(runtime, "y", regionMeasurement.frame.origin.y);
     jsiRegion.setProperty(runtime, "width", regionMeasurement.frame.size.width);
     jsiRegion.setProperty(runtime, "height", regionMeasurement.frame.size.height);
+    jsiRegion.setProperty(runtime, "region", regionMeasurement.region);
+    jsiRegion.setProperty(runtime, "line", regionMeasurement.line);
     regions.setValueAtIndex(runtime, i, jsiRegion);
   }
   

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.cpp
@@ -32,11 +32,16 @@ static jsi::Value linesMeasurementsPayload(
     lines.setValueAtIndex(runtime, i, jsiLine);
   }
   
-  if (regionsMeasurements.size() == 2) {
-    regions.setValueAtIndex(runtime, 0, regionsMeasurements[0]);
-    regions.setValueAtIndex(runtime, 1, regionsMeasurements[1]);
+  for (size_t i = 0; i < regionsMeasurements.size(); ++i) {
+    auto const &regionMeasurement = regionsMeasurements[i];
+    auto jsiRegion = jsi::Object(runtime);
+    jsiRegion.setProperty(runtime, "x", regionMeasurement.frame.origin.x);
+    jsiRegion.setProperty(runtime, "y", regionMeasurement.frame.origin.y);
+    jsiRegion.setProperty(runtime, "width", regionMeasurement.frame.size.width);
+    jsiRegion.setProperty(runtime, "height", regionMeasurement.frame.size.height);
+    regions.setValueAtIndex(runtime, i, jsiRegion);
   }
-
+  
   payload.setProperty(runtime, "lines", lines);
   payload.setProperty(runtime, "regions", regions);
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.h
@@ -17,11 +17,12 @@ class ParagraphEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
-  void onTextLayout(LinesMeasurements const &linesMeasurements) const;
+  void onTextLayout(LinesMeasurements const &linesMeasurements, RegionsMeasurements const &regionsMeasurements) const;
 
  private:
   mutable std::mutex linesMeasurementsMutex_;
   mutable LinesMeasurements linesMeasurementsMetrics_;
+  mutable RegionsMeasurements regionsMeasurementsMetrics_;
 };
 
 } // namespace react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
@@ -60,7 +60,7 @@ TextMeasurement ParagraphLayoutManager::measure(
   }
 }
 
-SegmentedMeasurements ParagraphLayoutManager::measureLines(
+TextLayoutMeasurements ParagraphLayoutManager::measureLines(
     AttributedString const &attributedString,
     ParagraphAttributes const &paragraphAttributes,
     Size size,

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
@@ -64,7 +64,7 @@ TextLayoutMeasurements ParagraphLayoutManager::measureLines(
     AttributedString const &attributedString,
     ParagraphAttributes const &paragraphAttributes,
     Size size,
-    std::vector<int> textLayoutRegions) const {
+    TextLayoutRegions textLayoutRegions) const {
   return textLayoutManager_->measureLines(
       attributedString, paragraphAttributes, size, textLayoutRegions);
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
@@ -60,12 +60,13 @@ TextMeasurement ParagraphLayoutManager::measure(
   }
 }
 
-LinesMeasurements ParagraphLayoutManager::measureLines(
+SegmentedMeasurements ParagraphLayoutManager::measureLines(
     AttributedString const &attributedString,
     ParagraphAttributes const &paragraphAttributes,
-    Size size) const {
+    Size size,
+    std::vector<int> textLayoutConfig) const {
   return textLayoutManager_->measureLines(
-      attributedString, paragraphAttributes, size);
+      attributedString, paragraphAttributes, size, textLayoutConfig);
 }
 
 void ParagraphLayoutManager::setTextLayoutManager(

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.cpp
@@ -64,9 +64,9 @@ SegmentedMeasurements ParagraphLayoutManager::measureLines(
     AttributedString const &attributedString,
     ParagraphAttributes const &paragraphAttributes,
     Size size,
-    std::vector<int> textLayoutConfig) const {
+    std::vector<int> textLayoutRegions) const {
   return textLayoutManager_->measureLines(
-      attributedString, paragraphAttributes, size, textLayoutConfig);
+      attributedString, paragraphAttributes, size, textLayoutRegions);
 }
 
 void ParagraphLayoutManager::setTextLayoutManager(

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
@@ -32,7 +32,7 @@ class ParagraphLayoutManager {
       AttributedString const &attributedString,
       ParagraphAttributes const &paragraphAttributes,
       Size size,
-      std::vector<int> textLayoutRegions) const;
+      TextLayoutRegions textLayoutRegions) const;
 
   void setTextLayoutManager(
       std::shared_ptr<TextLayoutManager const> textLayoutManager) const;

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
@@ -28,7 +28,7 @@ class ParagraphLayoutManager {
       ParagraphAttributes const &paragraphAttributes,
       LayoutConstraints layoutConstraints) const;
 
-  SegmentedMeasurements measureLines(
+  TextLayoutMeasurements measureLines(
       AttributedString const &attributedString,
       ParagraphAttributes const &paragraphAttributes,
       Size size,

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
@@ -32,7 +32,7 @@ class ParagraphLayoutManager {
       AttributedString const &attributedString,
       ParagraphAttributes const &paragraphAttributes,
       Size size,
-      std::vector<int> textLayoutConfig) const;
+      std::vector<int> textLayoutRegions) const;
 
   void setTextLayoutManager(
       std::shared_ptr<TextLayoutManager const> textLayoutManager) const;

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphLayoutManager.h
@@ -28,10 +28,11 @@ class ParagraphLayoutManager {
       ParagraphAttributes const &paragraphAttributes,
       LayoutConstraints layoutConstraints) const;
 
-  LinesMeasurements measureLines(
+  SegmentedMeasurements measureLines(
       AttributedString const &attributedString,
       ParagraphAttributes const &paragraphAttributes,
-      Size size) const;
+      Size size,
+      std::vector<int> textLayoutConfig) const;
 
   void setTextLayoutManager(
       std::shared_ptr<TextLayoutManager const> textLayoutManager) const;

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
@@ -39,13 +39,13 @@ ParagraphProps::ParagraphProps(
                                                        "selectable",
                                                        sourceProps.isSelectable,
                                                        false)),
-      textLayoutConfig(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.textLayoutConfig
+      textLayoutRegions(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.textLayoutRegions
                                                  : convertRawProp(
                                                        context,
                                                        rawProps,
-                                                       "textLayoutConfig",
-                                                       sourceProps.textLayoutConfig,
+                                                       "textLayoutRegions",
+                                                       sourceProps.textLayoutRegions,
                                                        {})),
       onTextLayout(
           CoreFeatures::enablePropIteratorSetter ? sourceProps.onTextLayout
@@ -131,7 +131,7 @@ void ParagraphProps::setProp(
   switch (hash) {
     RAW_SET_PROP_SWITCH_CASE_BASIC(isSelectable);
     RAW_SET_PROP_SWITCH_CASE_BASIC(onTextLayout);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(textLayoutConfig);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(textLayoutRegions);
   }
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
@@ -39,6 +39,14 @@ ParagraphProps::ParagraphProps(
                                                        "selectable",
                                                        sourceProps.isSelectable,
                                                        false)),
+      textLayoutConfig(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.textLayoutConfig
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "textLayoutConfig",
+                                                       sourceProps.textLayoutConfig,
+                                                       {})),
       onTextLayout(
           CoreFeatures::enablePropIteratorSetter ? sourceProps.onTextLayout
                                                  : convertRawProp(
@@ -123,6 +131,7 @@ void ParagraphProps::setProp(
   switch (hash) {
     RAW_SET_PROP_SWITCH_CASE_BASIC(isSelectable);
     RAW_SET_PROP_SWITCH_CASE_BASIC(onTextLayout);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(textLayoutConfig);
   }
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
@@ -9,6 +9,7 @@
 
 #include <limits>
 #include <memory>
+#include <vector>
 
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/components/text/BaseTextProps.h>
@@ -50,6 +51,11 @@ class ParagraphProps : public ViewProps, public BaseTextProps {
    * Defines can the text be selected (and copied) or not.
    */
   bool isSelectable{};
+
+  /*
+   * Defines text layout tracking strategy.
+   */
+  std::vector<int> textLayoutConfig{};
 
   bool onTextLayout{};
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
@@ -55,7 +55,7 @@ class ParagraphProps : public ViewProps, public BaseTextProps {
   /*
    * Defines text layout tracking strategy.
    */
-  std::vector<int> textLayoutConfig{};
+  std::vector<int> textLayoutRegions{};
 
   bool onTextLayout{};
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
@@ -16,6 +16,7 @@
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/textlayoutmanager/TextMeasureCache.h>
 
 namespace facebook {
 namespace react {
@@ -55,7 +56,7 @@ class ParagraphProps : public ViewProps, public BaseTextProps {
   /*
    * Defines text layout tracking strategy.
    */
-  std::vector<int> textLayoutRegions{};
+  TextLayoutRegions textLayoutRegions{};
 
   bool onTextLayout{};
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
@@ -9,7 +9,6 @@
 
 #include <limits>
 #include <memory>
-#include <vector>
 
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/components/text/BaseTextProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -164,7 +164,7 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
         content.attributedString,
         content.paragraphAttributes,
         measurement.size,
-        getConcreteProps().textLayoutConfig);
+        getConcreteProps().textLayoutRegions);
     
     getConcreteEventEmitter().onTextLayout(segmentedMeasurements.linesMeasurements, segmentedMeasurements.regionsMeasurements);
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -158,13 +158,15 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
 
   auto measurement = getStateData().paragraphLayoutManager.measure(
       content.attributedString, content.paragraphAttributes, layoutConstraints);
-
+  
   if (getConcreteProps().onTextLayout) {
-    auto linesMeasurements = getStateData().paragraphLayoutManager.measureLines(
+    auto segmentedMeasurements = getStateData().paragraphLayoutManager.measureLines(
         content.attributedString,
         content.paragraphAttributes,
-        measurement.size);
-    getConcreteEventEmitter().onTextLayout(linesMeasurements);
+        measurement.size,
+        getConcreteProps().textLayoutConfig);
+    
+    getConcreteEventEmitter().onTextLayout(segmentedMeasurements.linesMeasurements, segmentedMeasurements.regionsMeasurements);
   }
 
   if (content.attachments.empty()) {

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -160,13 +160,13 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
       content.attributedString, content.paragraphAttributes, layoutConstraints);
   
   if (getConcreteProps().onTextLayout) {
-    auto segmentedMeasurements = getStateData().paragraphLayoutManager.measureLines(
+    auto textLayoutMeasurements = getStateData().paragraphLayoutManager.measureLines(
         content.attributedString,
         content.paragraphAttributes,
         measurement.size,
         getConcreteProps().textLayoutRegions);
     
-    getConcreteEventEmitter().onTextLayout(segmentedMeasurements.linesMeasurements, segmentedMeasurements.regionsMeasurements);
+    getConcreteEventEmitter().onTextLayout(textLayoutMeasurements.linesMeasurements, textLayoutMeasurements.regionsMeasurements);
   }
 
   if (content.attachments.empty()) {

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.cpp
@@ -66,17 +66,32 @@ bool LineMeasurement::operator==(LineMeasurement const &rhs) const {
 }
 
 RegionMeasurement::RegionMeasurement(
-    Rect frame)
-    : frame(frame) {}
+    std::string text,
+    Rect frame,
+    int region,
+    int line)
+    : text(std::move(text)),
+      frame(frame),
+      region(region),
+      line(line) {}
 
 RegionMeasurement::RegionMeasurement(folly::dynamic const &data)
-    : frame(rectFromDynamic(data)) {}
+    : text(data.getDefault("text", "").getString()),
+      frame(rectFromDynamic(data)),
+      region(data.getDefault("region", 0).getInt()),
+      line(data.getDefault("line", 0).getInt()){}
 
 bool RegionMeasurement::operator==(RegionMeasurement const &rhs) const {
   return std::tie(
-             this->frame) ==
+             this->text,
+             this->frame,
+             this->region,
+             this->line) ==
       std::tie(
-             rhs.frame);
+             rhs.text,
+             rhs.frame,
+             rhs.region,
+             rhs.line);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.cpp
@@ -65,4 +65,18 @@ bool LineMeasurement::operator==(LineMeasurement const &rhs) const {
              rhs.xHeight);
 }
 
+RegionMeasurement::RegionMeasurement(
+    Rect frame)
+    : frame(frame) {}
+
+RegionMeasurement::RegionMeasurement(folly::dynamic const &data)
+    : frame(rectFromDynamic(data)) {}
+
+bool RegionMeasurement::operator==(RegionMeasurement const &rhs) const {
+  return std::tie(
+             this->frame) ==
+      std::tie(
+             rhs.frame);
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -41,7 +41,7 @@ struct LineMeasurement {
 using LinesMeasurements = std::vector<LineMeasurement>;
 using RegionsMeasurements = std::vector<float>;
 
-struct SegmentedMeasurements {
+struct TextLayoutMeasurements {
   LinesMeasurements linesMeasurements;
   RegionsMeasurements regionsMeasurements;
 };

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -53,7 +53,8 @@ struct RegionMeasurement {
 using LinesMeasurements = std::vector<LineMeasurement>;
 using RegionsMeasurements = std::vector<RegionMeasurement>;
 
-using TextLayoutRegions = std::vector<int>;
+using TextLayoutRegion = std::vector<int>;
+using TextLayoutRegions = std::vector<TextLayoutRegion>;
 
 struct TextLayoutMeasurements {
   LinesMeasurements linesMeasurements;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -38,8 +38,20 @@ struct LineMeasurement {
   bool operator==(LineMeasurement const &rhs) const;
 };
 
+struct RegionMeasurement {
+  Rect frame;
+
+  RegionMeasurement(
+      Rect frame
+  );
+
+  RegionMeasurement(folly::dynamic const &data);
+
+  bool operator==(RegionMeasurement const &rhs) const;
+};
+
 using LinesMeasurements = std::vector<LineMeasurement>;
-using RegionsMeasurements = std::vector<float>;
+using RegionsMeasurements = std::vector<RegionMeasurement>;
 
 struct TextLayoutMeasurements {
   LinesMeasurements linesMeasurements;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -53,6 +53,8 @@ struct RegionMeasurement {
 using LinesMeasurements = std::vector<LineMeasurement>;
 using RegionsMeasurements = std::vector<RegionMeasurement>;
 
+using TextLayoutRegions = std::vector<int>;
+
 struct TextLayoutMeasurements {
   LinesMeasurements linesMeasurements;
   RegionsMeasurements regionsMeasurements;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -39,10 +39,16 @@ struct LineMeasurement {
 };
 
 struct RegionMeasurement {
+  std::string text;
   Rect frame;
+  int region;
+  int line;
 
   RegionMeasurement(
-      Rect frame
+      std::string text,
+      Rect frame,
+      int region,
+      int line
   );
 
   RegionMeasurement(folly::dynamic const &data);

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -59,8 +59,7 @@ struct RegionMeasurement {
 using LinesMeasurements = std::vector<LineMeasurement>;
 using RegionsMeasurements = std::vector<RegionMeasurement>;
 
-using TextLayoutRegion = std::vector<int>;
-using TextLayoutRegions = std::vector<TextLayoutRegion>;
+using TextLayoutRegions = std::vector<std::vector<int>>;
 
 struct TextLayoutMeasurements {
   LinesMeasurements linesMeasurements;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -39,6 +39,12 @@ struct LineMeasurement {
 };
 
 using LinesMeasurements = std::vector<LineMeasurement>;
+using RegionsMeasurements = std::vector<float>;
+
+struct SegmentedMeasurements {
+  LinesMeasurements linesMeasurements;
+  RegionsMeasurements regionsMeasurements;
+};
 
 /*
  * Describes a result of text measuring.

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -239,19 +239,23 @@ TextLayoutMeasurements TextLayoutManager::measureLines(
               JReadableMapBuffer::javaobject,
               JReadableMapBuffer::javaobject,
               jfloat,
-              jfloat)>("measureLinesMapBuffer");
+              jfloat,
+              JReadableMapBuffer::javaobject)>("measureLinesMapBuffer");
 
   auto attributedStringMB =
       JReadableMapBuffer::createWithContents(toMapBuffer(attributedString));
   auto paragraphAttributesMB =
       JReadableMapBuffer::createWithContents(toMapBuffer(paragraphAttributes));
+  auto textLayoutRegionsMB =
+      JReadableMapBuffer::createWithContents(toMapBuffer(textLayoutRegions));
 
   auto object = measureLines(
       fabricUIManager,
       attributedStringMB.get(),
       paragraphAttributesMB.get(),
       size.width,
-      size.height);
+      size.height,
+      textLayoutRegionsMB.get());
 
   auto dynamicObject = cthis(object)->consume();
   LinesMeasurements lineMeasurements;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -67,10 +67,11 @@ class TextLayoutManager {
    * Measures lines of `attributedString` using native text rendering
    * infrastructure.
    */
-  LinesMeasurements measureLines(
+  TextLayoutMeasurements measureLines(
       AttributedString const &attributedString,
       ParagraphAttributes const &paragraphAttributes,
-      Size size) const;
+      Size size,
+      TextLayoutRegions textLayoutRegions) const;
 
   /*
    * Returns an opaque pointer to platform-specific TextLayoutManager.
@@ -89,10 +90,11 @@ class TextLayoutManager {
       ParagraphAttributes const &paragraphAttributes,
       LayoutConstraints layoutConstraints) const;
 
-  LinesMeasurements measureLinesMapBuffer(
+  TextLayoutMeasurements measureLinesMapBuffer(
       AttributedString const &attributedString,
       ParagraphAttributes const &paragraphAttributes,
-      Size size) const;
+      Size size,
+      TextLayoutRegions textLayoutRegions) const;
 
   void *self_{};
   ContextContainer::Shared contextContainer_;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.cpp
@@ -29,10 +29,11 @@ TextMeasurement TextLayoutManager::measure(
   return TextMeasurement{{0, 0}, attachments};
 }
 
-LinesMeasurements TextLayoutManager::measureLines(
+TextLayoutMeasurements TextLayoutManager::measureLines(
     AttributedString attributedString,
     ParagraphAttributes paragraphAttributes,
-    Size size) const {
+    Size size,
+    TextLayoutRegions textLayoutRegions) const {
   return {};
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.h
@@ -43,10 +43,11 @@ class TextLayoutManager {
    * Measures lines of `attributedString` using native text rendering
    * infrastructure.
    */
-  LinesMeasurements measureLines(
+  TextLayoutMeasurements measureLines(
       AttributedString attributedString,
       ParagraphAttributes paragraphAttributes,
-      Size size) const;
+      Size size,
+      TextLayoutRegions textLayoutRegions) const;
 
   /*
    * Returns an opaque pointer to platform-specific TextLayoutManager.

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.h
@@ -48,7 +48,7 @@ using RCTTextLayoutFragmentEnumerationBlock =
 - (facebook::react::SegmentedMeasurements)getLinesForAttributedString:(facebook::react::AttributedString)attributedString
                                                   paragraphAttributes:(facebook::react::ParagraphAttributes)paragraphAttributes
                                                                  size:(CGSize)size
-                                                     textLayoutConfig:(NSArray*)textLayoutConfig;
+                                                     textLayoutRegions:(NSArray*)textLayoutRegions;
 
 - (facebook::react::SharedEventEmitter)
     getEventEmitterWithAttributeString:(facebook::react::AttributedString)attributedString

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.h
@@ -45,7 +45,7 @@ using RCTTextLayoutFragmentEnumerationBlock =
                        frame:(CGRect)frame
                  textStorage:(NSTextStorage *_Nullable)textStorage;
 
-- (facebook::react::SegmentedMeasurements)getLinesForAttributedString:(facebook::react::AttributedString)attributedString
+- (facebook::react::TextLayoutMeasurements)getLinesForAttributedString:(facebook::react::AttributedString)attributedString
                                                   paragraphAttributes:(facebook::react::ParagraphAttributes)paragraphAttributes
                                                                  size:(CGSize)size
                                                      textLayoutRegions:(NSArray*)textLayoutRegions;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.h
@@ -45,10 +45,10 @@ using RCTTextLayoutFragmentEnumerationBlock =
                        frame:(CGRect)frame
                  textStorage:(NSTextStorage *_Nullable)textStorage;
 
-- (facebook::react::LinesMeasurements)getLinesForAttributedString:(facebook::react::AttributedString)attributedString
-                                              paragraphAttributes:
-                                                  (facebook::react::ParagraphAttributes)paragraphAttributes
-                                                             size:(CGSize)size;
+- (facebook::react::SegmentedMeasurements)getLinesForAttributedString:(facebook::react::AttributedString)attributedString
+                                                  paragraphAttributes:(facebook::react::ParagraphAttributes)paragraphAttributes
+                                                                 size:(CGSize)size
+                                                     textLayoutConfig:(NSArray*)textLayoutConfig;
 
 - (facebook::react::SharedEventEmitter)
     getEventEmitterWithAttributeString:(facebook::react::AttributedString)attributedString

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -134,7 +134,7 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   NSRange glyphRange = [layoutManager glyphRangeForTextContainer:textContainer];
 
   std::vector<LineMeasurement> paragraphLines{};
-  std::vector<float> regionsMeasurements{};
+  std::vector<RegionMeasurement> regionsMeasurements{};
   auto blockParagraphLines = &paragraphLines;
   auto blockRegionsMeasurements = &regionsMeasurements;
 
@@ -152,7 +152,7 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                                                      attribute:NSFontAttributeName
                                                        atIndex:0
                                                 effectiveRange:nil];
-                                            auto rect = facebook::react::Rect{
+                                            auto lineRect = facebook::react::Rect{
                                                 facebook::react::Point{usedRect.origin.x, usedRect.origin.y},
                                                 facebook::react::Size{usedRect.size.width, usedRect.size.height}};
                                                 
@@ -161,16 +161,18 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                                                 [[textLayoutRegions firstObject] integerValue]));
 
                                             [layoutManager enumerateEnclosingRectsForGlyphRange:lineRange
-                                                                        withinSelectedGlyphRange:lineRange
-                                                                                 inTextContainer:usedTextContainer
-                                                                                      usingBlock:^(CGRect enclosingRect, __unused BOOL *anotherStop) {
-                                              blockRegionsMeasurements->push_back(enclosingRect.size.width);
-                                              blockRegionsMeasurements->push_back(enclosingRect.size.height);
+                                                                       withinSelectedGlyphRange:lineRange
+                                                                                inTextContainer:usedTextContainer
+                                                                                     usingBlock:^(CGRect enclosingRect, __unused BOOL *anotherStop) {
+                                              auto regionRect = facebook::react::Rect{
+                                                  facebook::react::Point{enclosingRect.origin.x, enclosingRect.origin.y},
+                                                  facebook::react::Size{enclosingRect.size.width, enclosingRect.size.height}};
+                                              blockRegionsMeasurements->push_back(regionRect);
                                             }];
 
                                             auto line = LineMeasurement{
                                                 std::string([renderedString UTF8String]),
-                                                rect,
+                                                lineRect,
                                                 -font.descender,
                                                 font.capHeight,
                                                 font.ascender,

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -155,20 +155,23 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                                             auto lineRect = facebook::react::Rect{
                                                 facebook::react::Point{usedRect.origin.x, usedRect.origin.y},
                                                 facebook::react::Size{usedRect.size.width, usedRect.size.height}};
-                                                
-                                            NSRange lineRange = NSIntersectionRange(lineGlyphRange, NSMakeRange(
-                                                [[textLayoutRegions firstObject] integerValue],
-                                                [[textLayoutRegions firstObject] integerValue]));
+                                            
+                                            [textLayoutRegions enumerateObjectsUsingBlock:^(id _Nonnull textLayoutRegion, NSUInteger idx, BOOL * _Nonnull stop) {
+                                              auto from = [[textLayoutRegion firstObject] integerValue];
+                                              auto to = [[textLayoutRegion lastObject] integerValue];
+                                              NSRange lineRange = NSIntersectionRange(lineGlyphRange, NSMakeRange(from, to));
 
-                                            [layoutManager enumerateEnclosingRectsForGlyphRange:lineRange
-                                                                       withinSelectedGlyphRange:lineRange
-                                                                                inTextContainer:usedTextContainer
-                                                                                     usingBlock:^(CGRect enclosingRect, __unused BOOL *anotherStop) {
-                                              auto regionRect = facebook::react::Rect{
-                                                  facebook::react::Point{enclosingRect.origin.x, enclosingRect.origin.y},
-                                                  facebook::react::Size{enclosingRect.size.width, enclosingRect.size.height}};
-                                              blockRegionsMeasurements->push_back(regionRect);
+                                              [layoutManager enumerateEnclosingRectsForGlyphRange:lineRange
+                                                                         withinSelectedGlyphRange:lineRange
+                                                                                  inTextContainer:usedTextContainer
+                                                                                       usingBlock:^(CGRect enclosingRect, __unused BOOL *anotherStop) {
+                                                auto regionRect = facebook::react::Rect{
+                                                    facebook::react::Point{enclosingRect.origin.x, enclosingRect.origin.y},
+                                                    facebook::react::Size{enclosingRect.size.width, enclosingRect.size.height}};
+                                                blockRegionsMeasurements->push_back(regionRect);
+                                              }];
                                             }];
+                                            
 
                                             auto line = LineMeasurement{
                                                 std::string([renderedString UTF8String]),

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -123,7 +123,7 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
 - (SegmentedMeasurements)getLinesForAttributedString:(AttributedString)attributedString
                                  paragraphAttributes:(ParagraphAttributes)paragraphAttributes
                                                 size:(CGSize)size
-                                    textLayoutConfig:(NSArray*)textLayoutConfig
+                                    textLayoutRegions:(NSArray*)textLayoutRegions
 {
   NSTextStorage *textStorage = [self textStorageForAttributesString:attributedString
                                                 paragraphAttributes:paragraphAttributes
@@ -157,8 +157,8 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                                                 facebook::react::Size{usedRect.size.width, usedRect.size.height}};
                                                 
                                             NSRange lineRange = NSIntersectionRange(lineGlyphRange, NSMakeRange(
-                                                [[textLayoutConfig firstObject] integerValue],
-                                                [[textLayoutConfig firstObject] integerValue]));
+                                                [[textLayoutRegions firstObject] integerValue],
+                                                [[textLayoutRegions firstObject] integerValue]));
 
                                             [layoutManager enumerateEnclosingRectsForGlyphRange:lineRange
                                                                         withinSelectedGlyphRange:lineRange

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -120,7 +120,7 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
 #endif
 }
 
-- (SegmentedMeasurements)getLinesForAttributedString:(AttributedString)attributedString
+- (TextLayoutMeasurements)getLinesForAttributedString:(AttributedString)attributedString
                                  paragraphAttributes:(ParagraphAttributes)paragraphAttributes
                                                 size:(CGSize)size
                                     textLayoutRegions:(NSArray*)textLayoutRegions
@@ -178,9 +178,9 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                                             blockParagraphLines->push_back(line);
                                           }];
 
-  SegmentedMeasurements segmentedMeasurements = {paragraphLines, regionsMeasurements};
+  TextLayoutMeasurements textLayoutMeasurements = {paragraphLines, regionsMeasurements};
   
-  return segmentedMeasurements;
+  return textLayoutMeasurements;
 }
 
 - (NSTextStorage *)textStorageForAttributesString:(AttributedString)attributedString

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -40,10 +40,11 @@ class TextLayoutManager {
    * Measures lines of `attributedString` using native text rendering
    * infrastructure.
    */
-  LinesMeasurements measureLines(
+  SegmentedMeasurements measureLines(
       AttributedString attributedString,
       ParagraphAttributes paragraphAttributes,
-      Size size) const;
+      Size size,
+      std::vector<int> textLayoutConfig) const;
 
   std::shared_ptr<void> getHostTextStorage(
       AttributedString attributedString,

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -44,7 +44,7 @@ class TextLayoutManager {
       AttributedString attributedString,
       ParagraphAttributes paragraphAttributes,
       Size size,
-      std::vector<int> textLayoutConfig) const;
+      std::vector<int> textLayoutRegions) const;
 
   std::shared_ptr<void> getHostTextStorage(
       AttributedString attributedString,

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -44,7 +44,7 @@ class TextLayoutManager {
       AttributedString attributedString,
       ParagraphAttributes paragraphAttributes,
       Size size,
-      std::vector<int> textLayoutRegions) const;
+      TextLayoutRegions textLayoutRegions) const;
 
   std::shared_ptr<void> getHostTextStorage(
       AttributedString attributedString,

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -40,7 +40,7 @@ class TextLayoutManager {
    * Measures lines of `attributedString` using native text rendering
    * infrastructure.
    */
-  SegmentedMeasurements measureLines(
+  TextLayoutMeasurements measureLines(
       AttributedString attributedString,
       ParagraphAttributes paragraphAttributes,
       Size size,

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
@@ -109,10 +109,10 @@ SegmentedMeasurements TextLayoutManager::measureLines(
     AttributedString attributedString,
     ParagraphAttributes paragraphAttributes,
     Size size,
-    std::vector<int> textLayoutConfig) const
+    std::vector<int> textLayoutRegions) const
 {
   id chunks = [NSMutableArray new];
-  std::for_each(textLayoutConfig.begin(), textLayoutConfig.end(), ^(int chunk) {
+  std::for_each(textLayoutRegions.begin(), textLayoutRegions.end(), ^(int chunk) {
     id region = [NSNumber numberWithInteger:chunk];
     [chunks addObject:region];
   });
@@ -121,7 +121,7 @@ SegmentedMeasurements TextLayoutManager::measureLines(
   return [textLayoutManager getLinesForAttributedString:attributedString
                                     paragraphAttributes:paragraphAttributes
                                                    size:{size.width, size.height}
-                                       textLayoutConfig:chunks];
+                                       textLayoutRegions:chunks];
 }
 
 } // namespace react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
@@ -105,7 +105,7 @@ TextMeasurement TextLayoutManager::measure(
   return measurement;
 }
 
-SegmentedMeasurements TextLayoutManager::measureLines(
+TextLayoutMeasurements TextLayoutManager::measureLines(
     AttributedString attributedString,
     ParagraphAttributes paragraphAttributes,
     Size size,

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
@@ -109,7 +109,7 @@ TextLayoutMeasurements TextLayoutManager::measureLines(
     AttributedString attributedString,
     ParagraphAttributes paragraphAttributes,
     Size size,
-    std::vector<int> textLayoutRegions) const
+    TextLayoutRegions textLayoutRegions) const
 {
   id chunks = [NSMutableArray new];
   std::for_each(textLayoutRegions.begin(), textLayoutRegions.end(), ^(int chunk) {

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
@@ -105,15 +105,23 @@ TextMeasurement TextLayoutManager::measure(
   return measurement;
 }
 
-LinesMeasurements TextLayoutManager::measureLines(
+SegmentedMeasurements TextLayoutManager::measureLines(
     AttributedString attributedString,
     ParagraphAttributes paragraphAttributes,
-    Size size) const
+    Size size,
+    std::vector<int> textLayoutConfig) const
 {
+  id chunks = [NSMutableArray new];
+  std::for_each(textLayoutConfig.begin(), textLayoutConfig.end(), ^(int chunk) {
+    id region = [NSNumber numberWithInteger:chunk];
+    [chunks addObject:region];
+  });
+  
   RCTTextLayoutManager *textLayoutManager = (RCTTextLayoutManager *)unwrapManagedObject(self_);
   return [textLayoutManager getLinesForAttributedString:attributedString
                                     paragraphAttributes:paragraphAttributes
-                                                   size:{size.width, size.height}];
+                                                   size:{size.width, size.height}
+                                       textLayoutConfig:chunks];
 }
 
 } // namespace react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
@@ -111,17 +111,21 @@ TextLayoutMeasurements TextLayoutManager::measureLines(
     Size size,
     TextLayoutRegions textLayoutRegions) const
 {
-  id chunks = [NSMutableArray new];
-  std::for_each(textLayoutRegions.begin(), textLayoutRegions.end(), ^(int chunk) {
-    id region = [NSNumber numberWithInteger:chunk];
-    [chunks addObject:region];
-  });
-  
+  id regions = [NSMutableArray new];
+
+  for (auto const &textLayoutRegion : textLayoutRegions) {
+    id region = [NSMutableArray new];
+    for (auto const &chunk : textLayoutRegion) {
+      [region addObject:[NSNumber numberWithInteger:chunk]];
+    }
+    [regions addObject:region];
+  }
+
   RCTTextLayoutManager *textLayoutManager = (RCTTextLayoutManager *)unwrapManagedObject(self_);
   return [textLayoutManager getLinesForAttributedString:attributedString
                                     paragraphAttributes:paragraphAttributes
                                                    size:{size.width, size.height}
-                                       textLayoutRegions:chunks];
+                                      textLayoutRegions:regions];
 }
 
 } // namespace react

--- a/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
@@ -34,7 +34,7 @@ type State = {
   extraText?: string,
   imageLayout?: ViewLayout,
   textLayout?: ViewLayout,
-  textLayoutRegions?: TextLayoutEvent["nativeEvent"]["regions"],
+  textLayoutRegions?: TextLayoutEvent['nativeEvent']['regions'],
   viewLayout?: ViewLayout,
   viewStyle: {|margin: number|},
   ...
@@ -149,19 +149,18 @@ class LayoutEventExample extends React.Component<Props, State> {
             }
           </Text>
           <View>
-            {textRegions.map((region, index) => (
-              <View
-                key={index}
-                style={{
-                  width: region.width,
-                  height: region.height,
-                  top: region.y,
-                  left: region.x,
-                  backgroundColor: 'red',
-                  position: 'absolute',
-                }}
-              />
-            ))}
+            {textRegions.map((region, index) => {
+              const regionStyle = {
+                width: region.width,
+                height: region.height,
+                top: region.y,
+                left: region.x,
+              };
+              return (
+                // eslint-disable-next-line react-native/no-inline-styles
+                <View key={index} style={[regionStyle, styles.highlighted]} />
+              );
+            })}
             <Text
               onTextLayout={this.onTextRegionsLayout}
               textLayoutRegions={[[0, 111]]}
@@ -202,6 +201,10 @@ const styles = StyleSheet.create({
   },
   italicText: {
     fontStyle: 'italic',
+  },
+  highlighted: {
+    backgroundColor: 'red',
+    position: 'absolute',
   },
 });
 

--- a/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
@@ -157,7 +157,6 @@ class LayoutEventExample extends React.Component<Props, State> {
                 left: region.x,
               };
               return (
-                // eslint-disable-next-line react-native/no-inline-styles
                 <View key={index} style={[regionStyle, styles.highlighted]} />
               );
             })}


### PR DESCRIPTION
<!-- !!!!FILLING OUT THIS TEMPLATE COMPLETELY AND WITH GOOD QUALITY IS MANDATORY!!!! -->

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

# Upstream PR Link
https://github.com/facebook/react-native/pull/37397
<!-- For the Expensify fork of React-Native, every PR should also be made to the upstream source of React-Native. Provide a link to that PR here. If there is no upstream PR, write a good and detailed explanation of why. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I would like to apply styling to a substring of text, such as a background color, padding, and rounded corners. This functionality could be used for:

- **Username mention highlighting** (similar to Slack): Happy birthday `@username`
- **Inline code block** (similar to GitHub): Lorem Ipsum `is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen` book. 
<img width="443" alt="Screen Shot 2023-05-16 at 14 42 00" src="https://github.com/facebook/react-native/assets/4882133/393416d9-2a28-4653-9130-29d8c2e0dfdc">

The problem is that the Text element in RN behaves like a block element rather than an inline element when it is multiline. Additionally, it does not allow you to have borders or rounded corners. This makes it unsuitable for implementing a multiline inline code block.

Adding a new prop called textLayoutRegions which accepts an array of regions (substring positions) could be used to solve the problem. Passing this prop will calculate the regions [[start, end], [start, end] ...] position and pass the response into onTextLayout callback. Knowing exact substring position and dimensions will allow implementing custom styled View behind the text.

```js
<View>
  {regions.map((region, index) => (
    <View style={{width: region.width, height: region.height, top: region.y, left: region.x, backgroundColor: 'red', position: 'absolute'}} />
  ))}

  <Text style={{lineHeight: 20}} onTextLayout={event => setRegions(event.nativeEvent.regions)} textLayoutRegions={[[12, 242]]}>
    Lorem Ipsum  is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen  book.
  </Text>
</View>

// onTextLayout event
{
  lines: [...],
  regions: [
  {
    "height": 20,
    "line": 0,
    "region": 0,
    "text": " is simply dummy text of the printing and typesetting ",
    "width": 325.71429443359375,
    "x": 85.42857360839844,
    "y": 0
  },
  {
    "height": 20,
    "line": 1,
    "region": 0,
    "text": "industry. Lorem Ipsum has been the industry's standard dummy ",
    "width": 393.71429443359375,
    "x": 0,
    "y": 20
  },
  {
    "height": 20,
    "line": 2,
    "region": 0,
    "text": "text ever since the 1500s, when an unknown printer took a galley ",
    "width": 400.28570556640625,
    "x": 0,
    "y": 40
  },
  {
    "height": 20,
    "line": 3,
    "region": 0,
    "text": "of type and scrambled it to make a type specimen  ",
    "width": 313.1428527832031,
    "x": 0,
    "y": 60
  }
]
}
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [ADDED] - New `textLayoutRegions` prop for Text component that accepts an array of substring regions. Each region's layout position will be appended into `onTextLayout` event callback.
[GENERAL] [ADDED] - New `regions` props for `onTextLayout` event callback.


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Run RNTester app
- Go to APIs → Layout Events page
- Ensure substring has a red background color around selected region