### PR TITLE
Fix Multiline TextInput with a fixed height scrolls to the bottom when prepending new lines to the text

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -148,7 +148,9 @@ static UIColor *defaultPlaceholderColor()
 
 - (void)setAttributedText:(NSAttributedString *)attributedText
 {
+  self.scrollEnabled = false;
   [super setAttributedText:attributedText];
+  self.scrollEnabled = true;
   [self textDidChange];
 }
 


### PR DESCRIPTION
<!-- !!!!FILLING OUT THIS TEMPLATE COMPLETELY AND WITH GOOD QUALITY IS MANDATORY!!!! -->

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

# Upstream PR Link
<!-- For the Expensify fork of React-Native, every PR should also be made to the upstream source of React-Native. Provide a link to that PR here. If there is no upstream PR, write a good and detailed explanation of why. -->
Upstream PR https://github.com/facebook/react-native/pull/38679
fixes https://github.com/Expensify/App/issues/19507

## Summary:

### Please re-state the problem that we are trying to solve in this issue.

Multiline TextInput with a fixed height will scroll to the bottom of the screen when prepending new lines to the text.

### What is the root cause of that problem?

The issue is caused by iOS UITextView:
- The cursor moves to the end of the text when prepending new lines. 
- Moving the cursor to the end of the text triggers the scroll to the bottom.

The behavior was reproduced on an iOS App (without react-native). 
The example included below implements a Component RCTUITextView based on UITextView, which modifies the UITextView attributedText with the textViewDidChange callback (source code available in this [comment](https://github.com/Expensify/App/issues/19507#issuecomment-1595730348)). 

Adding a new line on top of the UITextView on iOS results in:
Issue 1) The cursor moves to the end of TextInput text
Issue 2) The TextInput scrolls to the bottom

<details><summary>Reproducing the issue on an iOS App without react-native</summary>
<p>

<video src="https://user-images.githubusercontent.com/24992535/246601549-99f480f3-ce80-4678-9378-f71c8aa67e17.mp4" width="900" />

</p>
</details>


Issue 1) is already fixed in react-native, which restores the previous cursor position (on Fabric with  [_setAttributedString](https://github.com/fabriziobertoglio1987/react-native/blob/71e7bbbc2cf21abacf7009e300f5bba737e20d17/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm#L600-L610)) after changing the text.
Issue 2) needs to be fixed in react-native.

### What changes do you think we should make in order to solve the problem?

Disable scrollingEnabled when changing the attributedText.

## Changelog:

[IOS] [FIXED] - Fix Multiline TextInput with a fixed height scrolls to the bottom when prepending new lines to the text

## Test Plan:

Fabric (reproduces on controlled/not controlled TextInput example):

| Before    | After |
| ----------- | ----------- |
| <video src="https://github.com/facebook/react-native/assets/24992535/e06b31fe-407d-4897-b608-73e0cc0f224a" width="350" />      | <video src="https://github.com/facebook/react-native/assets/24992535/fa2eaa31-c616-43c5-9596-f84e7b70d80a" width="350" />       |

Paper (reproduces only on controlled TextInput example):

```javascript
function TextInputExample() {
  const [text, setText] = React.useState('');

  return (
    <View style={{marginTop: 200}}>
      <TextInput
        style={{height: 50, backgroundColor: 'white'}}
        multiline={true}
        value={text}
        onChangeText={text => {
          setText(text);
        }}
      />
    </View>
  );
}
```

| Before    | After |
| ----------- | ----------- |
| <video src="https://github.com/facebook/react-native/assets/24992535/6cb1f2de-717e-4dce-be0a-644f6a051c08" width="350" />      | <video src="https://github.com/facebook/react-native/assets/24992535/dee6edb6-76c6-48b0-b78f-99626235d30e" width="350" />       |

Expensify

| Before    | After |
| ----------- | ----------- |
| <video src="https://user-images.githubusercontent.com/24992535/256965962-6cb5ac6b-76a8-4fca-8d80-715be6d8ca4b.mp4" width="350" />      | <video src="https://user-images.githubusercontent.com/24992535/256966083-82418520-5296-4e42-877f-ebce401826d4.mp4" width="350" />       |


